### PR TITLE
iterate over key value pair instead of just keys

### DIFF
--- a/applicationinsights/channel/TelemetryChannel.py
+++ b/applicationinsights/channel/TelemetryChannel.py
@@ -101,7 +101,7 @@ class TelemetryChannel(object):
             if not properties:
                 properties = {}
                 data.properties = properties
-            for key, value in local_context.properties:
+            for key, value in local_context.properties.items():
                 if key not in properties:
                     properties[key] = value
         envelope.data.base_data = data


### PR DESCRIPTION
local_context.properties only returns the set of keys and thus throws a "ValueError: too many values to unpack" when trying to unwrap it into (key, value) tuple