### PR TITLE
Fix send_timeout setter

### DIFF
--- a/applicationinsights/channel/SenderBase.py
+++ b/applicationinsights/channel/SenderBase.py
@@ -77,7 +77,7 @@ class SenderBase(object):
             seconds(float). Timeout in seconds.
         """
 
-        self._send_buffer_size = seconds
+        self._timeout = seconds
 
     @queue.setter
     def queue(self, value):


### PR DESCRIPTION
`SenderBase.send_timeout` setter actually sets value to wrong field `self._send_buffer_size = seconds`