### PR TITLE
Check that the request object has the user attribute

### DIFF
--- a/applicationinsights/django/middleware.py
+++ b/applicationinsights/django/middleware.py
@@ -127,8 +127,9 @@ class ApplicationInsightsMiddleware(object):
         context.user.user_agent = request.META.get('HTTP_USER_AGENT', '')
 
         # User
-        if request.user is not None and not request.user.is_anonymous and request.user.is_authenticated:
-            context.user.account_id = request.user.get_short_name()
+        if hasattr(request, 'user'):
+            if request.user is not None and not request.user.is_anonymous and request.user.is_authenticated:
+                context.user.account_id = request.user.get_short_name()
 
         # Run and time the request
         addon.start_stopwatch()


### PR DESCRIPTION
Check that a Django request object has the user attribute. This is necessary if a Django project does not have the auth middleware that sets request.user.