### PR TITLE
Add common properties argument to WSGIApplication wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
+## 0.11.5
+- Add common properties argument to WSGIApplication initialization.
+
 ## 0.11.4
 - Schemas for all data types and context objects updated to the latest version.
 
-
 ## 0.11.3
-
-Changelog started from this version.
+- Changelog started from this version.

--- a/README.md
+++ b/README.md
@@ -302,6 +302,32 @@ For any other Python web framework that is [WSGI compliant](https://www.python.o
 the [WSGIApplication](https://github.com/Microsoft/ApplicationInsights-Python/blob/master/applicationinsights/requests/WSGIApplication.py)
 can be used as a middleware to log requests to Application Insights.
 
+Add common properties to WSGIApplication request events by passing in a dictionary to the WSGIApplication constructor:
+```
+from flask import Flask
+from applicationinsights.requests import WSGIApplication
+
+# instantiate the Flask application and wrap its WSGI application
+app = Flask(__name__)
+
+# Construct dictionary which contains properties to be included with every request event
+common_properties = {
+    "service": "hello_world_flask_app",
+    "environment": "production"
+}
+
+app.wsgi_app = WSGIApplication('<YOUR INSTRUMENTATION KEY GOES HERE>', app.wsgi_app, common_properties=common_properties)
+
+# define a simple route
+@app.route('/')
+def hello_world():
+    return 'Hello World!'
+
+# run the application
+if __name__ == '__main__':
+    app.run()
+```
+
 
 ## Publishing new version to pypi.python.org
 

--- a/applicationinsights/requests/WSGIApplication.py
+++ b/applicationinsights/requests/WSGIApplication.py
@@ -25,7 +25,7 @@ class WSGIApplication(object):
                 app = config.make_wsgi_app()
 
                 # Enable Application Insights middleware
-                app = WSGIApplication('<YOUR INSTRUMENTATION KEY GOES HERE>', app)
+                app = WSGIApplication('<YOUR INSTRUMENTATION KEY GOES HERE>', app, common_properties={'service': 'hello_world_service'})
 
                 serve(app, host='0.0.0.0')
     """

--- a/applicationinsights/requests/WSGIApplication.py
+++ b/applicationinsights/requests/WSGIApplication.py
@@ -49,6 +49,7 @@ class WSGIApplication(object):
         self.client = applicationinsights.TelemetryClient(instrumentation_key, telemetry_channel)
         self.client.context.device.type = "PC"
         self._wsgi_application = wsgi_application
+        self._common_properties = kwargs.pop('common_properties', {})
 
     def flush(self):
         """Flushes the queued up telemetry to the service.
@@ -104,4 +105,4 @@ class WSGIApplication(object):
         end_time = datetime.datetime.utcnow()
         duration = int((end_time - start_time).total_seconds() * 1000)
 
-        self.client.track_request(name, url, success, start_time.isoformat() + 'Z', duration, response_code, http_method)
+        self.client.track_request(name, url, success, start_time.isoformat() + 'Z', duration, response_code, http_method, self._common_properties)


### PR DESCRIPTION
Our Flask app cannot log common properties/dimensions when it uses the default WSGIApplication wrapper. I have updated the wrapper construct to take in a new common_properties object. This is similar to the code used in the NodeJS Application Insight Telemetry Logger: https://github.com/Microsoft/ApplicationInsights-node.js/blob/develop/Library/TelemetryClient.ts#L36

These common properties are then logged for every track_request made by the WSGIApplication wrapper.

