### PR TITLE
Fix display of code in GitHub README preview

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,6 +186,7 @@ Once installed, you can send telemetry to Application Insights. Here are a few s
 **Integrating with Flask**
 
 .. code:: python
+
     from flask import Flask
     from applicationinsights.flask.ext import AppInsights
     
@@ -210,6 +211,7 @@ Once installed, you can send telemetry to Application Insights. Here are a few s
 Place the following in your `settings.py` file:
 
 .. code:: python
+
     # If on Django < 1.10
     MIDDLEWARE_CLASSES = [
         # ... or whatever is below for you ...
@@ -287,6 +289,7 @@ Django warnings and errors, use the following logging configuration in
 `settings.py`:
 
 .. code:: python
+
     LOGGING = {
         'version': 1,
         'disable_existing_loggers': False,
@@ -318,6 +321,7 @@ can be used as a middleware to log requests to Application Insights.
 Add common properties to WSGIApplication request events by passing in a dictionary to the WSGIApplication constructor:
 
 .. code:: python
+
     from flask import Flask
     from applicationinsights.requests import WSGIApplication
 


### PR DESCRIPTION
The display of some of the code examples in the README is currently broken on GitHub: the code snippets don't render due to missing newlines after the `.. code:: python` block declaration. This pull request fixes that.

**Screenshot of README before this pull request:**

![Screenshot of README before this pull request](https://user-images.githubusercontent.com/1086421/41814304-5e362664-7716-11e8-8e10-4d48163dfb79.png)

**Screenshot of README after this pull request:**

![Screenshot of README after this pull request](https://user-images.githubusercontent.com/1086421/41814292-43e7c8b2-7716-11e8-872d-ffe56f55129d.png)
