### PR TITLE
Fix support for context.properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.11.5
 
+- Fixed setting custom properties through context. [#102](https://github.com/Microsoft/ApplicationInsights-Python/pull/102)
+
 ## 0.11.4
 
 - Schemas for all data types and context objects updated to the latest version.

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,7 @@ Once installed, you can send telemetry to Application Insights. Here are a few s
     tc.context.device.model = 'X31A'
     tc.context.device.type = "Other"
     tc.context.user.id = 'santa@northpole.net'
+    tc.context.properties['my_property'] = 'my_value'
     tc.track_trace('My trace with context')
     tc.flush()
 
@@ -125,7 +126,7 @@ Once installed, you can send telemetry to Application Insights. Here are a few s
     logging.info('This is a message')
 
     # logging shutdown will cause a flush of all un-sent telemetry items
-    # alternatively flush manually via handler.flush()
+    logging.shutdown()
 
 **Basic logging configuration (second option)**
 
@@ -149,16 +150,23 @@ Once installed, you can send telemetry to Application Insights. Here are a few s
 
     # logging shutdown will cause a flush of all un-sent telemetry items
     # alternatively flush manually via handler.flush()
+    logging.shutdown()
 
 **Advanced logging configuration**
 
 .. code:: python
 
     import logging
+    from applicationinsights import channel
     from applicationinsights.logging import LoggingHandler
 
+    # set up channel with context
+    telemetry_channel = channel.TelemetryChannel()
+    telemetry_channel.context.application.ver = '1.2.3'
+    telemetry_channel.context.properties['my_property'] = 'my_value'
+
     # set up logging
-    handler = LoggingHandler('<YOUR INSTRUMENTATION KEY GOES HERE>')
+    handler = LoggingHandler('<YOUR INSTRUMENTATION KEY GOES HERE>', telemetry_channel=telemetry_channel)
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
     my_logger = logging.getLogger('simple_logger')
@@ -170,6 +178,7 @@ Once installed, you can send telemetry to Application Insights. Here are a few s
 
     # logging shutdown will cause a flush of all un-sent telemetry items
     # alternatively flush manually via handler.flush()
+    logging.shutdown()
 
 **Logging unhandled exceptions**
 
@@ -182,6 +191,28 @@ Once installed, you can send telemetry to Application Insights. Here are a few s
 
     # raise an exception (this will be sent to the Application Insights service as an exception telemetry object)
     raise Exception('Boom!')
+
+    # exceptions will cause a flush of all un-sent telemetry items
+
+**Logging unhandled exceptions with context**
+
+.. code:: python
+
+    from applicationinsights import channel
+    from applicationinsights.exceptions import enable
+
+    # set up channel with context
+    telemetry_channel = channel.TelemetryChannel()
+    telemetry_channel.context.application.ver = '1.2.3'
+    telemetry_channel.context.properties['my_property'] = 'my_value'
+
+    # set up exception capture
+    enable('<YOUR INSTRUMENTATION KEY GOES HERE>', telemetry_channel=telemetry_channel)
+
+    # raise an exception (this will be sent to the Application Insights service as an exception telemetry object)
+    raise Exception('Boom!')
+
+    # exceptions will cause a flush of all un-sent telemetry items
 
 **Integrating with Flask**
 

--- a/applicationinsights/TelemetryClient.py
+++ b/applicationinsights/TelemetryClient.py
@@ -24,9 +24,8 @@ class TelemetryClient(object):
                 instrumentation_key = None
         else:
             raise Exception('Instrumentation key was required but not provided')
-        self._context = channel.TelemetryContext()
-        self._context.instrumentation_key = instrumentation_key
         self._channel = telemetry_channel or channel.TelemetryChannel()
+        self.context.instrumentation_key = instrumentation_key
 
     @property
     def context(self):
@@ -36,7 +35,7 @@ class TelemetryClient(object):
         Returns:
             :class:`channel.TelemetryChannel`. the context instance.
         """
-        return self._context
+        return self._channel.context
 
     @property
     def channel(self):
@@ -73,7 +72,7 @@ class TelemetryClient(object):
         if measurements:
             data.measurements = measurements
 
-        self._channel.write(data, self._context)
+        self._channel.write(data)
 
     def track_exception(self, type=None, value=None, tb=None, properties=None, measurements=None):
         """ Send information about a single exception that occurred in the application.
@@ -120,7 +119,7 @@ class TelemetryClient(object):
         if measurements:
             data.measurements = measurements
 
-        self._channel.write(data, self._context)
+        self._channel.write(data)
 
     def track_event(self, name, properties=None, measurements=None):
         """ Send information about a single event that has occurred in the context of the application.
@@ -137,7 +136,7 @@ class TelemetryClient(object):
         if measurements:
             data.measurements = measurements
 
-        self._channel.write(data, self._context)
+        self._channel.write(data)
 
     def track_metric(self, name, value, type=None, count=None, min=None, max=None, std_dev=None, properties=None):
         """Send information about a single metric data point that was captured for the application.
@@ -166,7 +165,7 @@ class TelemetryClient(object):
         if properties:
             data.properties = properties
 
-        self._channel.write(data, self._context)
+        self._channel.write(data)
 
     def track_trace(self, name, properties=None, severity=None):
         """Sends a single trace statement.
@@ -183,7 +182,7 @@ class TelemetryClient(object):
         if severity is not None:
             data.severity_level = channel.contracts.MessageData.PYTHON_LOGGING_LEVELS.get(severity)
 
-        self._channel.write(data, self._context)
+        self._channel.write(data)
 
     def track_request(self, name, url, success, start_time=None, duration=None, response_code=None, http_method=None, properties=None, measurements=None):
         """Sends a single request that was captured for the application.
@@ -224,5 +223,5 @@ class TelemetryClient(object):
         if measurements:
             data.measurements = measurements
 
-        self.channel.write(data, self._context)
+        self.channel.write(data)
 

--- a/applicationinsights/TelemetryClient.py
+++ b/applicationinsights/TelemetryClient.py
@@ -24,8 +24,9 @@ class TelemetryClient(object):
                 instrumentation_key = None
         else:
             raise Exception('Instrumentation key was required but not provided')
+        self._context = channel.TelemetryContext()
+        self._context.instrumentation_key = instrumentation_key
         self._channel = telemetry_channel or channel.TelemetryChannel()
-        self.context.instrumentation_key = instrumentation_key
 
     @property
     def context(self):
@@ -35,7 +36,7 @@ class TelemetryClient(object):
         Returns:
             :class:`channel.TelemetryChannel`. the context instance.
         """
-        return self._channel.context
+        return self._context
 
     @property
     def channel(self):
@@ -72,7 +73,7 @@ class TelemetryClient(object):
         if measurements:
             data.measurements = measurements
 
-        self._channel.write(data)
+        self._channel.write(data, self._context)
 
     def track_exception(self, type=None, value=None, tb=None, properties=None, measurements=None):
         """ Send information about a single exception that occurred in the application.
@@ -119,7 +120,7 @@ class TelemetryClient(object):
         if measurements:
             data.measurements = measurements
 
-        self._channel.write(data)
+        self._channel.write(data, self._context)
 
     def track_event(self, name, properties=None, measurements=None):
         """ Send information about a single event that has occurred in the context of the application.
@@ -136,7 +137,7 @@ class TelemetryClient(object):
         if measurements:
             data.measurements = measurements
 
-        self._channel.write(data)
+        self._channel.write(data, self._context)
 
     def track_metric(self, name, value, type=None, count=None, min=None, max=None, std_dev=None, properties=None):
         """Send information about a single metric data point that was captured for the application.
@@ -165,7 +166,7 @@ class TelemetryClient(object):
         if properties:
             data.properties = properties
 
-        self._channel.write(data)
+        self._channel.write(data, self._context)
 
     def track_trace(self, name, properties=None, severity=None):
         """Sends a single trace statement.
@@ -182,7 +183,7 @@ class TelemetryClient(object):
         if severity is not None:
             data.severity_level = channel.contracts.MessageData.PYTHON_LOGGING_LEVELS.get(severity)
 
-        self._channel.write(data)
+        self._channel.write(data, self._context)
 
     def track_request(self, name, url, success, start_time=None, duration=None, response_code=None, http_method=None, properties=None, measurements=None):
         """Sends a single request that was captured for the application.
@@ -223,5 +224,5 @@ class TelemetryClient(object):
         if measurements:
             data.measurements = measurements
 
-        self.channel.write(data)
+        self.channel.write(data, self._context)
 

--- a/applicationinsights/channel/TelemetryChannel.py
+++ b/applicationinsights/channel/TelemetryChannel.py
@@ -98,9 +98,6 @@ class TelemetryChannel(object):
         envelope.data.base_type = data.DATA_TYPE_NAME
         if hasattr(data, 'properties') and local_context.properties:
             properties = data.properties
-            if not properties:
-                properties = {}
-                data.properties = properties
             for key in local_context.properties:
                 if key not in properties:
                     properties[key] = local_context.properties[key]

--- a/applicationinsights/channel/TelemetryChannel.py
+++ b/applicationinsights/channel/TelemetryChannel.py
@@ -96,11 +96,14 @@ class TelemetryChannel(object):
             tags[key] = value
         envelope.data = contracts.Data()
         envelope.data.base_type = data.DATA_TYPE_NAME
-        if hasattr(data, 'properties') and local_context.properties:
-            properties = data.properties
-            for key in local_context.properties:
-                if key not in properties:
-                    properties[key] = local_context.properties[key]
+        for prop_context in [context, self._context]:
+            if not prop_context:
+                continue
+            if hasattr(data, 'properties') and prop_context.properties:
+                properties = data.properties
+                for key in prop_context.properties:
+                    if key not in properties:
+                        properties[key] = prop_context.properties[key]
         envelope.data.base_data = data
 
         self._queue.put(envelope)

--- a/tests/applicationinsights_tests/TestTelemetryClient.py
+++ b/tests/applicationinsights_tests/TestTelemetryClient.py
@@ -67,6 +67,39 @@ class TestTelemetryClient(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(expected, actual)
 
+    def test_track_event_with_merged_context_properties_works_as_expected(self):
+        key = '99999999-9999-9999-9999-999999999999'
+        sender = MockTelemetrySender()
+        queue = channel.SynchronousQueue(sender)
+        
+        chan = channel.TelemetryChannel(queue=queue)
+        chan.context.properties['foo'] = 'bar'
+
+        client1 = TelemetryClient(key, chan)
+        client1.context.device = None
+        client1.context.properties['x'] = 42
+
+        client2 = TelemetryClient(key, chan)
+        client2.context.device = None
+        client2.context.properties['x'] = 84
+
+        client1.track_event('test 1')
+        client1.flush()
+        sender.data.time = 'TIME_PLACEHOLDER'
+        sender.data.tags['ai.internal.sdkVersion'] = 'SDK_VERSION_PLACEHOLDER'
+        actual = json.dumps(sender.data.write())
+        expected = '{"ver": 1, "name": "Microsoft.ApplicationInsights.Event", "time": "TIME_PLACEHOLDER", "sampleRate": 100.0, "iKey": "99999999-9999-9999-9999-999999999999", "tags": {"ai.internal.sdkVersion": "SDK_VERSION_PLACEHOLDER"}, "data": {"baseType": "EventData", "baseData": {"ver": 2, "name": "test 1", "properties": {"foo": "bar", "x": 42}}}}'
+        self.maxDiff = None
+        self.assertEqual(expected, actual)
+
+        client2.track_event('test 2')
+        client2.flush()
+        sender.data.time = 'TIME_PLACEHOLDER'
+        sender.data.tags['ai.internal.sdkVersion'] = 'SDK_VERSION_PLACEHOLDER'
+        actual = json.dumps(sender.data.write())
+        expected = '{"ver": 1, "name": "Microsoft.ApplicationInsights.Event", "time": "TIME_PLACEHOLDER", "sampleRate": 100.0, "iKey": "99999999-9999-9999-9999-999999999999", "tags": {"ai.internal.sdkVersion": "SDK_VERSION_PLACEHOLDER"}, "data": {"baseType": "EventData", "baseData": {"ver": 2, "name": "test 2", "properties": {"foo": "bar", "x": 84}}}}'
+        self.assertEqual(expected, actual)
+
     def test_track_metric_works_as_expected(self):
         sender = MockTelemetrySender()
         queue = channel.SynchronousQueue(sender)

--- a/tests/applicationinsights_tests/exception_tests/TestEnable.py
+++ b/tests/applicationinsights_tests/exception_tests/TestEnable.py
@@ -15,6 +15,7 @@ class TestEnable(unittest.TestCase):
         sender = MockSynchronousSender()
         queue = channel.SynchronousQueue(sender)
         telemetry_channel = channel.TelemetryChannel(None, queue)
+        telemetry_channel.context.properties["foo"] = "bar"
         exceptions.enable('foo', telemetry_channel=telemetry_channel)
         try:
             raise Exception('Boom')
@@ -25,6 +26,7 @@ class TestEnable(unittest.TestCase):
         self.assertIsNotNone(data)
         self.assertEqual('foo', data.ikey)
         self.assertEqual('Microsoft.ApplicationInsights.Exception', data.name)
+        self.assertEqual('bar', data.data.base_data.properties['foo'])
 
     def test_enable_raises_exception_on_no_instrumentation_key(self):
         self.assertRaises(Exception, exceptions.enable, None)

--- a/tests/applicationinsights_tests/logging_tests/TestLoggingHandler.py
+++ b/tests/applicationinsights_tests/logging_tests/TestLoggingHandler.py
@@ -6,7 +6,7 @@ rootDirectory = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 
 if rootDirectory not in sys.path:
     sys.path.append(rootDirectory)
 
-from applicationinsights import logging, channel
+from applicationinsights import logging
 
 class TestEnable(unittest.TestCase):
     def test_enable(self):
@@ -106,9 +106,6 @@ class TestLoggingHandler(unittest.TestCase):
 
 
 class MockChannel:
-    def __init__(self):
-        self.context = channel.TelemetryContext()
-       
     def flush(self):
         pass
 

--- a/tests/applicationinsights_tests/logging_tests/TestLoggingHandler.py
+++ b/tests/applicationinsights_tests/logging_tests/TestLoggingHandler.py
@@ -6,7 +6,7 @@ rootDirectory = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 
 if rootDirectory not in sys.path:
     sys.path.append(rootDirectory)
 
-from applicationinsights import logging
+from applicationinsights import logging, channel
 
 class TestEnable(unittest.TestCase):
     def test_enable(self):
@@ -43,7 +43,7 @@ class TestLoggingHandler(unittest.TestCase):
         self.assertRaises(Exception, logging.LoggingHandler, None)
 
     def test_log_works_as_expected(self):
-        logger, sender = self._setup_logger()
+        logger, sender, channel = self._setup_logger()
 
         expected = [
             (logger.debug, 'debug message', 'Microsoft.ApplicationInsights.Message', 'test', 'MessageData', 0, 'simple_logger - DEBUG - debug message'),
@@ -62,9 +62,14 @@ class TestLoggingHandler(unittest.TestCase):
             self.assertEqual(data_type, data.data.base_type)
             self.assertEqual(message, data.data.base_data.message)
             self.assertEqual(severity_level, data.data.base_data.severity_level)
+        
+        channel.context.properties['foo'] = 'bar'
+        logger.info('info message')
+        data = sender.data[0][0]
+        self.assertEqual('bar', data.data.base_data.properties['foo'])
 
     def test_log_exception_works_as_expected(self):
-        logger, sender = self._setup_logger()
+        logger, sender, _ = self._setup_logger()
 
         try:
             raise Exception('blah')
@@ -84,9 +89,11 @@ class TestLoggingHandler(unittest.TestCase):
         handler = logging.LoggingHandler('test')
         handler.setLevel(pylogging.DEBUG)
 
+        channel = handler.client.channel
+
         # mock out the sender
         sender = MockSynchronousSender()
-        queue = handler.client.channel.queue
+        queue = channel.queue
         queue.max_queue_length = 1
         queue._sender = sender
         sender.queue = queue
@@ -95,10 +102,13 @@ class TestLoggingHandler(unittest.TestCase):
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
-        return logger, sender
+        return logger, sender, channel
 
 
 class MockChannel:
+    def __init__(self):
+        self.context = channel.TelemetryContext()
+       
     def flush(self):
         pass
 


### PR DESCRIPTION
If the event has no properties or `{}` then the context properties are not used either. Only when the event has some properties, e.g. `client.track_event('test', {"x": 42})` then the context properties are picked up. This PR adds a failing test that should succeed. I don't know what the solution is but this should help with fixing the bug.