### PR TITLE
Fix Flask integration AttributeError on Python 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.11.6
 
+- Fixed exception logging in Flask integration on Python 2.
+
 ## 0.11.5
 
 - Fixed setting custom properties through context. [#102](https://github.com/Microsoft/ApplicationInsights-Python/pull/102)

--- a/applicationinsights/flask/ext.py
+++ b/applicationinsights/flask/ext.py
@@ -159,12 +159,12 @@ class AppInsights(object):
 
         @app.errorhandler(Exception)
         def exception_handler(exception):
-            exception_telemetry_client.track_exception(
-                type=type(exception),
-                value=exception,
-                tb=exception.__traceback__)
-
-            raise exception
+            try:
+                raise exception
+            except Exception:
+                exception_telemetry_client.track_exception()
+            finally:
+                raise exception
 
         self._exception_telemetry_client = exception_telemetry_client
 


### PR DESCRIPTION
The `__traceback__` attribute for exceptions was only introduced in
Python 3 so the current way of sending exception information to
Application Insights from Flask fails in Python 2. This change fixes
that by re-raising the exception and using `sys.exc_info` under the hood
to gather the exception information.