### PR TITLE
Make logging from Flask more explicit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -243,6 +243,9 @@ Since operation_id is being set as a property of telemetry client, the client sh
     # define a simple route
     @app.route('/')
     def hello_world():
+        # the following message will be sent to the Flask log as well as Application Insights
+        app.logger.info('Hello World route was called')
+
         return 'Hello World!'
 
     # run the application


### PR DESCRIPTION
We got some user feedback that their logs weren't being sent to
Application Insights from the Flask integration. This was due to a
confusion between the Python rooter logger `logging.debug(...)` and the
Flask loggers `app.logger.debug(...)`. The Flask integration only sends
the latter logs to Application Insights since mutating the root logger
from a third party package would be surprising behavior.

This change makes it explicit in the documentation how the logger has to
be used so that the messages to end up in Application Insights.