### PR TITLE
Add api link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ To install the latest release you can use `pip <http://www.pip-installer.org/>`_
 Documentation
 -------------
 
-Please see <https://microsoft.github.io/ApplicationInsights-Python/> for full documentation.
+Please see https://microsoft.github.io/ApplicationInsights-Python/ for full documentation.
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,11 @@ To install the latest release you can use `pip <http://www.pip-installer.org/>`_
 
     $ pip install applicationinsights
 
+Documentation
+-------------
+
+Please see <https://microsoft.github.io/ApplicationInsights-Python/> for full documentation.
+
 Usage
 -----
 


### PR DESCRIPTION
This was in reference to issue #100. After I started, I noticed that @Alhern already added the link to the docs.

However, I felt like the docs should get their own section in the readme. I left in the previous change as to increase the chances that the link will be seen.