### PR TITLE
Travis CI: Python 3.4 --> 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
 - '2.7'
-- '3.4'
+- '3.6'
 script:
 - python setup.py sdist
 - python setup.py test


### PR DESCRIPTION
Python 3.4 will end of life in the coming weeks so let's start testing on a more up-to-date version.
* https://devguide.python.org/#branchstatus