### PR TITLE
Extract constant for default sender endpoint

### DIFF
--- a/applicationinsights/channel/AsynchronousSender.py
+++ b/applicationinsights/channel/AsynchronousSender.py
@@ -1,4 +1,4 @@
-from .SenderBase import SenderBase
+from .SenderBase import SenderBase, DEFAULT_ENDPOINT_URL
 from threading import Lock, Thread
 
 class AsynchronousSender(SenderBase):
@@ -13,7 +13,7 @@ class AsynchronousSender(SenderBase):
     If no queue items are found for :func:`send_time` seconds, the worker thread will shut down (and :func:`start` will
     need  to be called again).
     """
-    def __init__(self, service_endpoint_uri='https://dc.services.visualstudio.com/v2/track'):
+    def __init__(self, service_endpoint_uri=None):
         """Initializes a new instance of the class.
 
         Args:
@@ -23,7 +23,7 @@ class AsynchronousSender(SenderBase):
         self._send_remaining_time = 0
         self._send_time = 3.0
         self._lock_send_remaining_time = Lock()
-        SenderBase.__init__(self, service_endpoint_uri)
+        SenderBase.__init__(self, service_endpoint_uri or DEFAULT_ENDPOINT_URL)
 
     @property
     def send_interval(self):

--- a/applicationinsights/channel/SenderBase.py
+++ b/applicationinsights/channel/SenderBase.py
@@ -9,6 +9,8 @@ except ImportError:
     import urllib.request as HTTPClient
     from urllib.error import HTTPError
 
+DEFAULT_ENDPOINT_URL = 'https://dc.services.visualstudio.com/v2/track'
+
 class SenderBase(object):
     """The base class for all types of senders for use in conjunction with an implementation of :class:`QueueBase`.
 

--- a/applicationinsights/channel/SynchronousSender.py
+++ b/applicationinsights/channel/SynchronousSender.py
@@ -1,13 +1,13 @@
-from .SenderBase import SenderBase
+from .SenderBase import SenderBase, DEFAULT_ENDPOINT_URL
 
 class SynchronousSender(SenderBase):
     """A synchronous sender that works in conjunction with the :class:`SynchronousQueue`. The queue will call
     :func:`send` on the current instance with the data to send.
     """
-    def __init__(self, service_endpoint_uri='https://dc.services.visualstudio.com/v2/track'):
+    def __init__(self, service_endpoint_uri=None):
         """Initializes a new instance of the class.
 
         Args:
             sender (String) service_endpoint_uri the address of the service to send telemetry data to.
         """
-        SenderBase.__init__(self, service_endpoint_uri)
+        SenderBase.__init__(self, service_endpoint_uri or DEFAULT_ENDPOINT_URL)

--- a/applicationinsights/django/common.py
+++ b/applicationinsights/django/common.py
@@ -53,10 +53,7 @@ def create_client(aisettings=None):
     if channel_settings in saved_channels:
         channel = saved_channels[channel_settings]
     else:
-        if channel_settings.endpoint is not None:
-            sender = applicationinsights.channel.AsynchronousSender(service_endpoint_uri=channel_settings.endpoint)
-        else:
-            sender = applicationinsights.channel.AsynchronousSender()
+        sender = applicationinsights.channel.AsynchronousSender(service_endpoint_uri=channel_settings.endpoint)
 
         if channel_settings.send_time is not None:
             sender.send_time = channel_settings.send_time

--- a/applicationinsights/flask/ext.py
+++ b/applicationinsights/flask/ext.py
@@ -92,11 +92,7 @@ class AppInsights(object):
             return
 
         self._endpoint_uri = app.config.get(CONF_ENDPOINT_URI)
-
-        if self._endpoint_uri:
-            sender = AsynchronousSender(self._endpoint_uri)
-        else:
-            sender = AsynchronousSender()
+        sender = AsynchronousSender(self._endpoint_uri)
 
         queue = AsynchronousQueue(sender)
         self._channel = TelemetryChannel(None, queue)

--- a/django_tests/tests.py
+++ b/django_tests/tests.py
@@ -6,6 +6,7 @@ from django.test import TestCase, Client, modify_settings, override_settings
 
 from applicationinsights import TelemetryClient
 from applicationinsights.channel import TelemetryChannel, SynchronousQueue, SenderBase, NullSender, AsynchronousSender
+from applicationinsights.channel.SenderBase import DEFAULT_ENDPOINT_URL as DEFAULT_ENDPOINT
 from applicationinsights.django import common
 
 if django.VERSION > (1, 10):
@@ -15,7 +16,6 @@ else:
 
 TEST_IKEY = '12345678-1234-5678-9012-123456789abc'
 TEST_ENDPOINT = 'https://test.endpoint/v2/track'
-DEFAULT_ENDPOINT = AsynchronousSender().service_endpoint_uri
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
 class AITestCase(TestCase):


### PR DESCRIPTION
This change brings three main benefits:

1) Clients can now programmatically access the value of the default sender endpoint, for example to forward requests to it. This benefit is demonstrated by the changes to the test code.

2) Avoid copy/paste of the endpoint URL between async and sync senders.

3) Defaulting the service_endpoint_url to None instead of the string value and checking against null later to look up the default endpoint url means that the class now supports use-cases like `Sender(os.getenv('SERVICE_URL'))` which simplifies client code that may want to optionally override the service url. This benefit is demonstrated by the changes to the Django and Flask integrations.