### PR TITLE
Introduce 'ai.cloud.roleName' setter and getter

### DIFF
--- a/applicationinsights/channel/contracts/Cloud.py
+++ b/applicationinsights/channel/contracts/Cloud.py
@@ -39,7 +39,30 @@ class Cloud(object):
             del self._values['ai.cloud.role']
         else:
             self._values['ai.cloud.role'] = value
-        
+
+    @property
+    def role_name(self):
+        """The role_name property.
+
+        Returns:
+            (string). the property value. (defaults to: None)
+        """
+        if 'ai.cloud.roleName' in self._values:
+            return self._values['ai.cloud.roleName']            
+        return self._defaults['ai.cloud.roleName']
+
+    @role_name.setter
+    def role_name.setter(self, value):
+        """ The role_name property.
+
+        Args:
+            value (string). the property value
+        """ 
+        if value == self._defaults['ai.cloud.roleName'] and 'ai.cloud.roleName' in self_values:
+            def self._values['ai.cloud.roleName']
+        else:
+            self._values['ai.cloud.roleName'] =  value
+
     @property
     def role_instance(self):
         """The role_instance property.
@@ -51,6 +74,7 @@ class Cloud(object):
             return self._values['ai.cloud.roleInstance']
         return self._defaults['ai.cloud.roleInstance']
         
+
     @role_instance.setter
     def role_instance(self, value):
         """The role_instance property.


### PR DESCRIPTION
In order to visualize cloud applications on the Application insights Application Map, each application requires the cloud_RoleName parameter to be passed along with telemetry. This parameter is added with this pull request. 

> NOTE: <br />
> I've followed the same naming convention as the code originally has, however, AI documentation suggests explicitly that the parameter be named **cloud_RoleName** - I'm not sure if casing will make a problem of this or not. Do advise and provide feedback before accepting this PR.