### PR TITLE
Add option to customize log level in enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (will be 0.11.8)
 
 - Allow to specify and endpoint to upload telemetry to.
+- Add `level` argument to `logging.enable` to configure telemetry verbosity.
 
 ## 0.11.7
 

--- a/applicationinsights/logging/LoggingHandler.py
+++ b/applicationinsights/logging/LoggingHandler.py
@@ -24,6 +24,9 @@ def enable(instrumentation_key, *args, **kwargs):
     Args:
         instrumentation_key (str). the instrumentation key to use while sending telemetry to the service.
 
+    Keyword Args:
+        level (Union[int, str]): The level to set for the logger. Defaults to INFO.
+
     Returns:
         :class:`ApplicationInsightsHandler`. the newly created or existing handler.
     """
@@ -31,8 +34,9 @@ def enable(instrumentation_key, *args, **kwargs):
         raise Exception('Instrumentation key was required but not provided')
     if instrumentation_key in enabled_instrumentation_keys:
         logging.getLogger().removeHandler(enabled_instrumentation_keys[instrumentation_key])
+    log_level = kwargs.pop('level', logging.INFO)
     handler = LoggingHandler(instrumentation_key, *args, **kwargs)
-    handler.setLevel(logging.INFO)
+    handler.setLevel(log_level)
     enabled_instrumentation_keys[instrumentation_key] = handler
     logging.getLogger().addHandler(handler)
     return handler

--- a/tests/applicationinsights_tests/logging_tests/TestLoggingHandler.py
+++ b/tests/applicationinsights_tests/logging_tests/TestLoggingHandler.py
@@ -29,6 +29,12 @@ class TestEnable(unittest.TestCase):
         pylogging.getLogger().removeHandler(handler2)
         pylogging.getLogger().removeHandler(handler3)
 
+    def test_enable_with_level(self):
+        handler = logging.enable('foo', level='DEBUG')
+        self.assertIsNotNone(handler)
+        self.assertEqual(handler.level, pylogging.DEBUG)
+        pylogging.getLogger().removeHandler(handler)
+
     def test_enable_raises_exception_on_no_instrumentation_key(self):
         self.assertRaises(Exception, logging.enable, None)
 


### PR DESCRIPTION
This removes an assumption that the log level should always be INFO by enabling users to call the function like so:

```py
import logging
from applicationinsights.logging import enable

enable('my-instrumentation-key', level=logging.DEBUG)
```

It could be argued the the same can be achieved via: `enable('key').setLevel(logging.DEBUG)`, but this somewhat leaks the logging handler implementation detail and leaves the current implicit `INFO` level undocumented.