### PR TITLE
Ensure CI and PyPI Python versions match

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
 - '2.7'
+- '3.4'
+- '3.5'
 - '3.6'
 script:
 - python setup.py sdist

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
The classifiers list in `setup.py` mentions support for Python 3.4 and yet the CI on Travis doesn't run the tests on that version which means that we can't be certain that the package works correctly on the declared version.

To fix this discrepancy, this change makes the Python versions used during CI match up with the Python versions declared in the classifiers list.