### PR TITLE
Fix memory leak in logging.enable

### DIFF
--- a/applicationinsights/logging/LoggingHandler.py
+++ b/applicationinsights/logging/LoggingHandler.py
@@ -1,7 +1,8 @@
 import logging
 import applicationinsights
+from weakref import WeakValueDictionary
 
-enabled_instrumentation_keys = {}
+enabled_instrumentation_keys = WeakValueDictionary()
 
 def enable(instrumentation_key, *args, **kwargs):
     """Enables the Application Insights logging handler for the root logger for the supplied instrumentation key.

--- a/tests/applicationinsights_tests/logging_tests/TestLoggingHandler.py
+++ b/tests/applicationinsights_tests/logging_tests/TestLoggingHandler.py
@@ -7,6 +7,7 @@ if rootDirectory not in sys.path:
     sys.path.append(rootDirectory)
 
 from applicationinsights import logging
+from applicationinsights.logging.LoggingHandler import enabled_instrumentation_keys
 
 class TestEnable(unittest.TestCase):
     def test_enable(self):
@@ -31,6 +32,20 @@ class TestEnable(unittest.TestCase):
 
     def test_enable_raises_exception_on_no_instrumentation_key(self):
         self.assertRaises(Exception, logging.enable, None)
+
+    def test_handler_removal_clears_cache(self):
+        def enable_telemetry():
+            logging.enable('key1')
+
+        def remove_telemetry_handlers():
+            for handler in pylogging.getLogger().handlers:
+                if isinstance(handler, logging.LoggingHandler):
+                    pylogging.getLogger().removeHandler(handler)
+
+        enable_telemetry()
+        self.assertIn('key1', enabled_instrumentation_keys)
+        remove_telemetry_handlers()
+        self.assertNotIn('key1', enabled_instrumentation_keys)
 
 
 class TestLoggingHandler(unittest.TestCase):


### PR DESCRIPTION
The `logging.enable` function caches references to the `LoggingHandler` instances that it creates in a dictionary private to the module.

This means that references to the handler objects survive even if they were removed from all loggers that referenced them, causing two undesirable side-effects:

1) The `LoggingHandler` instances created by `logging.enable` can never be reclaimed by the garbage collector.

2) Removing all references to the `LoggingHandler` from the logger doesn't mark the instrumentation key as "no longer used" in the `logging.enable` module.

This change fixes these issues by replacing the cache with a `WeakValueDictionary`: as soon as the last reference to the `LoggingHandler` is removed (e.g. when `some_logger.removeHandler(...)` is called), the `WeakValueDictionary` will also evict its cached entry.