### PR TITLE
Add option to set async and endpoint in enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased (will be 0.11.8)
 
 - Allow to specify and endpoint to upload telemetry to.
+- Add `async_` argument to `logging.enable` to use async telemetry channel.
+- Add `endpoint` argument to `logging.enable` to configure custom telemetry endpoint.
 
 ## 0.11.7
 

--- a/applicationinsights/logging/LoggingHandler.py
+++ b/applicationinsights/logging/LoggingHandler.py
@@ -1,5 +1,8 @@
 import logging
 import applicationinsights
+from applicationinsights.channel import AsynchronousSender, AsynchronousQueue
+from applicationinsights.channel import SynchronousSender, SynchronousQueue
+from applicationinsights.channel import TelemetryChannel
 
 enabled_instrumentation_keys = {}
 
@@ -19,10 +22,14 @@ def enable(instrumentation_key, *args, **kwargs):
         logging.info('This is a message')
 
         # logging shutdown will cause a flush of all un-sent telemetry items
-        # alternatively set up an async channel via enable('<YOUR INSTRUMENTATION KEY GOES HERE>', telemetry_channel=...)
+        # alternatively set up an async channel via enable('<YOUR INSTRUMENTATION KEY GOES HERE>', async_=True)
 
     Args:
         instrumentation_key (str). the instrumentation key to use while sending telemetry to the service.
+
+    Keyword Args:
+        async_ (bool): Whether to use an async channel for the telemetry. Defaults to False.
+        endpoint (str): The custom endpoint to which to send the telemetry. Defaults to None.
 
     Returns:
         :class:`ApplicationInsightsHandler`. the newly created or existing handler.
@@ -31,6 +38,19 @@ def enable(instrumentation_key, *args, **kwargs):
         raise Exception('Instrumentation key was required but not provided')
     if instrumentation_key in enabled_instrumentation_keys:
         logging.getLogger().removeHandler(enabled_instrumentation_keys[instrumentation_key])
+    async_ = kwargs.pop('async_', False)
+    endpoint = kwargs.pop('endpoint', None)
+    telemetry_channel = kwargs.get('telemetry_channel')
+    if telemetry_channel and async_:
+        raise Exception('Incompatible arguments async_ and telemetry_channel')
+    if telemetry_channel and endpoint:
+        raise Exception('Incompatible arguments endpoint and telemetry_channel')
+    if not telemetry_channel:
+        if async_:
+            sender, queue = AsynchronousSender, AsynchronousQueue
+        else:
+            sender, queue = SynchronousSender, SynchronousQueue
+        kwargs['telemetry_channel'] = TelemetryChannel(queue=queue(sender(endpoint)))
     handler = LoggingHandler(instrumentation_key, *args, **kwargs)
     handler.setLevel(logging.INFO)
     enabled_instrumentation_keys[instrumentation_key] = handler

--- a/tests/applicationinsights_tests/logging_tests/TestLoggingHandler.py
+++ b/tests/applicationinsights_tests/logging_tests/TestLoggingHandler.py
@@ -2,6 +2,10 @@ import unittest
 import logging as pylogging
 
 import sys, os, os.path
+
+from applicationinsights.channel import AsynchronousQueue, AsynchronousSender
+from applicationinsights.channel import SynchronousQueue, SynchronousSender
+
 rootDirectory = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..')
 if rootDirectory not in sys.path:
     sys.path.append(rootDirectory)
@@ -14,6 +18,8 @@ class TestEnable(unittest.TestCase):
         self.assertIsNotNone(handler1)
         self.assertEqual('LoggingHandler', handler1.__class__.__name__)
         self.assertEqual('foo', handler1.client.context.instrumentation_key)
+        self.assertIsInstance(handler1.client.channel.queue, SynchronousQueue)
+        self.assertIsInstance(handler1.client.channel.sender, SynchronousSender)
         handler2 = logging.enable('foo')
         self.assertEqual('LoggingHandler', handler2.__class__.__name__)
         self.assertEqual('foo', handler2.client.context.instrumentation_key)
@@ -28,6 +34,25 @@ class TestEnable(unittest.TestCase):
         self.assertIn(handler3, all_handlers)
         pylogging.getLogger().removeHandler(handler2)
         pylogging.getLogger().removeHandler(handler3)
+
+    def test_enable_with_endpoint(self):
+        handler = logging.enable('foo', endpoint='http://bar')
+        self.assertEqual(handler.client.channel.sender.service_endpoint_uri, 'http://bar')
+        pylogging.getLogger().removeHandler(handler)
+
+    def test_enable_with_async(self):
+        handler = logging.enable('foo', async_=True)
+        self.assertIsInstance(handler.client.channel.queue, AsynchronousQueue)
+        self.assertIsInstance(handler.client.channel.sender, AsynchronousSender)
+        pylogging.getLogger().removeHandler(handler)
+
+    def test_enable_raises_exception_on_async_with_telemetry_channel(self):
+        with self.assertRaises(Exception):
+            logging.enable('foo', async_=True, telemetry_channel=MockChannel())
+
+    def test_enable_raises_exception_on_endpoint_with_telemetry_channel(self):
+        with self.assertRaises(Exception):
+            logging.enable('foo', endpoint='http://bar', telemetry_channel=MockChannel())
 
     def test_enable_raises_exception_on_no_instrumentation_key(self):
         self.assertRaises(Exception, logging.enable, None)


### PR DESCRIPTION
It's a very common use-case to set up AppInsights telemetry in a project
and customize the telemetry channel to be asynchronous; for example to
transparently integrate AppInsights into an existing daemon, worker
thread or webserver that already uses the logging module. It's currently
tedious if the user always has to write the same code over and over
again to import the AsynchronousQueue, AsynchronousSender,
TelemetryChannel, write them all up, before being able to pass them into
the enable function. As such, this change introduces a new shortcut that
lets the user specify async mode as a high-level concept on the enable
function.

This change simplifies the following code:

```py
from applicationinsights.logging import enable
from applicationinsights.channel import AsynchronousQueue
from applicationinsights.channel import AsynchronousSender
from applicationinsights.channel import TelemetryChannel

sender = AsynchronousSender()
queue = AsynchronousQueue(sender)
channel = TelemetryChannel(queue=queue)

enable('my-instrumentation-key', telemetry_channel=channel)
```

The new code is much nicer for the user:

```py
from applicationinsights.logging import enable

enable('my-instrumentation-key', async_=True)
```

As a companion to this new functionality, this change also introduces an
argument that lets the user customize the endpoint to which the
telemetry is being sent:

```py
from applicationinsights.logging import enable

enable('my-instrumentation-key', async_=True, endpoint='http://custom')
```

Together, the two new arguments raise the enable function to feature
parity with the other high level integrations (e.g. Django or Flask) in
terms of ease of developer use and high-level API.