### PR TITLE
Add option to make the telemetry queue persistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - '2.7'
 - '3.6'
 script:
+- pip install persist-queue
 - python setup.py sdist
 - python setup.py test
 - django_tests/all_tests.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (will be 0.11.8)
 
 - Allow to specify and endpoint to upload telemetry to.
+- Add optional queue persistence to prevent telemetry loss in case of application crash.
 
 ## 0.11.7
 

--- a/applicationinsights/channel/AsynchronousQueue.py
+++ b/applicationinsights/channel/AsynchronousQueue.py
@@ -6,14 +6,11 @@ class AsynchronousQueue(QueueBase):
     will notify the sender that it needs to pick up items when it reaches :func:`max_queue_length`, or
     when the consumer calls :func:`flush` via the :func:`flush_notification` event.
     """
-    def __init__(self, sender):
+    def __init__(self, *args, **kwargs):
         """Initializes a new instance of the class.
-
-        Args:
-            sender (:class:`SenderBase`) the sender object that will be used in conjunction with this queue.
         """
         self._flush_notification = Event()
-        QueueBase.__init__(self, sender)
+        QueueBase.__init__(self, *args, **kwargs)
 
     @property
     def flush_notification(self):

--- a/applicationinsights/channel/SynchronousQueue.py
+++ b/applicationinsights/channel/SynchronousQueue.py
@@ -12,14 +12,6 @@ class SynchronousQueue(QueueBase):
         queue.max_queue_length = 1
         queue.put(1)
     """
-    def __init__(self, sender):
-        """Initializes a new instance of the class.
-
-        Args:
-            sender (:class:`SenderBase`) the sender object that will be used in conjunction with this queue.
-        """
-        QueueBase.__init__(self, sender)
-
     def flush(self):
         """Flushes the current queue by by calling :func:`sender`'s :func:`send` method.
         """


### PR DESCRIPTION
Currently the Application Insights client SDK already has some great resiliency built-in, e.g. retrying to send telemetry if there are intermittent connectivity issues or service interruptions. However,
there still is a risk to lose telemetry if the app crashes before sending telemetry since the telemetry queue is in-memory only.

This change adds an option to persist the queue to disk via the [persist-queue](https://pypi.org/project/persist-queue/) module which will protect customers against potential data loss, at the cost of a slight loss in performance.