### PR TITLE
Fix bug when NullSender is used with Async Queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (will be 0.11.8)
 
 - Allow to specify and endpoint to upload telemetry to.
+- Add support for using `NullSender` with `AsynchronousQueue`.
 
 ## 0.11.7
 

--- a/applicationinsights/channel/NullSender.py
+++ b/applicationinsights/channel/NullSender.py
@@ -9,3 +9,9 @@ class NullSender(SenderBase):
 
     def send(self, data):
         pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass

--- a/tests/applicationinsights_tests/channel_tests/TestAsynchronousQueue.py
+++ b/tests/applicationinsights_tests/channel_tests/TestAsynchronousQueue.py
@@ -43,6 +43,13 @@ class TestAsynchronousQueue(unittest.TestCase):
         result = queue.flush_notification.wait()
         self.assertEqual(True, result)
 
+    def test_with_null_sender(self):
+        sender = channel.NullSender()
+        queue = channel.AsynchronousQueue(sender)
+        queue.put(1)
+        queue.put(2)
+        queue.flush()
+
 
 class MockAsynchronousSender:
     def __init__(self):


### PR DESCRIPTION
Currently the NullSender crashes when used in conjunction with AsynchronousQueue since the AsynchronousQueue relies on some methods that are not part of the SenderBase interface.

This limitation leads to unexpected behavior when for example using the NullSender to avoid sending telemetry in an application when the instrumentation key isn't configured in the environment.

This change makes the NullSender work with the AsynchronousQueue so that the class can be used with both queues included in the SDK.