### PR TITLE
Add accessor for the Flask telemetry context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (will be 0.11.8)
 
 - Allow to specify and endpoint to upload telemetry to.
+- Add option to set telemetry context for Flask integration.
 
 ## 0.11.7
 

--- a/applicationinsights/flask/ext.py
+++ b/applicationinsights/flask/ext.py
@@ -101,6 +101,16 @@ class AppInsights(object):
         self._init_trace_logging(app)
         self._init_exception_logging(app)
 
+    @property
+    def context(self):
+        """
+        Accesses the telemetry context.
+
+        Returns:
+            (applicationinsights.channel.TelemetryContext). The Application Insights telemetry context.
+        """
+        return self._channel.context
+
     def _init_request_logging(self, app):
         """
         Sets up request logging unless ``APPINSIGHTS_DISABLE_REQUEST_LOGGING``


### PR DESCRIPTION
This enables use-cases to set custom properties to be sent along the telemetry such as a user id or a role name.

Resolves https://github.com/Microsoft/ApplicationInsights-Python/issues/136
Resolves https://github.com/Microsoft/ApplicationInsights-Python/issues/146