### PR TITLE
Avoid swallowing flask control-flow exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased (will be 0.11.8)
 
 - Allow to specify and endpoint to upload telemetry to.
+- Fix Flask>=1.0 exception handler catching control-flow exceptions.
 
 ## 0.11.7
 

--- a/applicationinsights/flask/ext.py
+++ b/applicationinsights/flask/ext.py
@@ -1,5 +1,10 @@
 from os import getenv
 
+try:
+    from werkzeug.exceptions import HTTPException
+except ImportError:
+    HTTPException = None
+
 from applicationinsights import TelemetryClient
 from applicationinsights.channel import AsynchronousSender
 from applicationinsights.channel import AsynchronousQueue
@@ -155,6 +160,9 @@ class AppInsights(object):
 
         @app.errorhandler(Exception)
         def exception_handler(exception):
+            if HTTPException and isinstance(exception, HTTPException):
+                return exception
+
             try:
                 raise exception
             except Exception:


### PR DESCRIPTION
The Flask 1.0 release changed the semantics of `@app.errorhandler(Exception)`.

Previously, this feature would catch application internal exceptions only. Since the Flask 1.0 release, this now catches all exceptions, including werkzeug's HTTPException which is used internally by Flask for control flow, e.g. 404 not found, 403 forbidden, etc. The side-effect of this change is that the AppInsights exception handler now translated these control flow exceptions into uncaught exceptions, i.e. HTTP 500 errors.

This change makes the AppInsights exception handler more robust to no longer swallow the control-flow exceptions.

Resolves https://github.com/Microsoft/ApplicationInsights-Python/issues/124