### PR TITLE
Added OT Distro and Configurator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
 ## Unreleased
-
+- Added OpenTelemetry Distro and Configurator
+    ([#187](https://github.com/microsoft/ApplicationInsights-Python/pull/187))
 - Initial commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,7 @@ zip_safe = False
 include_package_data = True
 install_requires =
     azure-monitor-opentelemetry-exporter == 1.0.0b6
-    opentelemetry-api == 1.11.1
     opentelemetry-instrumentation == 0.32b0
-    opentelemetry-sdk == 1.11.1
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,8 @@ include_package_data = True
 install_requires =
     azure-monitor-opentelemetry-exporter == 1.0.0b6
     opentelemetry-instrumentation == 0.32b0
-    opentelemetry-sdk == 1.12.0rc2
-    opentelemetry-api == 1.12.0rc2
+    opentelemetry-sdk == 1.11.1
+    opentelemetry-api == 1.11.1
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,3 +36,9 @@ install_requires =
 
 [options.packages.find]
 where = src
+
+[options.entry_points]
+opentelemetry_distro =
+    azure_monitor_opentelemetry_distro = azure.monitor.opentelemetry.distro.distro:AzureMonitorDistro
+opentelemetry_configurator =
+    azure_monitor_opentelemetry_configurator = azure.monitor.opentelemetry.distro.configurator:AzureMonitorConfigurator

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,9 +33,9 @@ zip_safe = False
 include_package_data = True
 install_requires =
     azure-monitor-opentelemetry-exporter == 1.0.0b6
+    opentelemetry-api == 1.11.1
     opentelemetry-instrumentation == 0.32b0
     opentelemetry-sdk == 1.11.1
-    opentelemetry-api == 1.11.1
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ packages=find_namespace:
 zip_safe = False
 include_package_data = True
 install_requires =
-    azure-monitor-opentelemetry-exporter == 1.0.0b6
+    azure-monitor-opentelemetry-exporter == 1.0.0b7
     opentelemetry-instrumentation == 0.32b0
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,9 @@ zip_safe = False
 include_package_data = True
 install_requires =
     azure-monitor-opentelemetry-exporter == 1.0.0b6
+    opentelemetry-instrumentation == 0.32b0
+    opentelemetry-sdk == 1.12.0rc2
+    opentelemetry-api == 1.12.0rc2
 
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@
 # --------------------------------------------------------------------------
 
 import os
-
 import setuptools
 
 BASE_DIR = os.path.dirname(__file__)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 # --------------------------------------------------------------------------
 
 import os
+
 import setuptools
 
 BASE_DIR = os.path.dirname(__file__)

--- a/src/azure/monitor/opentelemetry/distro/configurator.py
+++ b/src/azure/monitor/opentelemetry/distro/configurator.py
@@ -6,5 +6,6 @@
 
 from opentelemetry.sdk._configuration import _OTelSDKConfigurator
 
+
 class AzureMonitorConfigurator(_OTelSDKConfigurator):
     pass

--- a/src/azure/monitor/opentelemetry/distro/configurator.py
+++ b/src/azure/monitor/opentelemetry/distro/configurator.py
@@ -1,0 +1,10 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+from opentelemetry.sdk._configuration import _OTelSDKConfigurator
+
+class AzureMonitorConfigurator(_OTelSDKConfigurator):
+    pass

--- a/src/azure/monitor/opentelemetry/distro/distro.py
+++ b/src/azure/monitor/opentelemetry/distro/distro.py
@@ -5,12 +5,11 @@
 # --------------------------------------------------------------------------
 
 from os import environ
+
+from opentelemetry.environment_variables import (OTEL_LOGS_EXPORTER,
+                                                 OTEL_METRICS_EXPORTER,
+                                                 OTEL_TRACES_EXPORTER)
 from opentelemetry.instrumentation.distro import BaseDistro
-from opentelemetry.environment_variables import (
-    OTEL_LOGS_EXPORTER,
-    OTEL_METRICS_EXPORTER,
-    OTEL_TRACES_EXPORTER,
-)
 
 
 class AzureMonitorDistro(BaseDistro):

--- a/src/azure/monitor/opentelemetry/distro/distro.py
+++ b/src/azure/monitor/opentelemetry/distro/distro.py
@@ -10,6 +10,6 @@ from opentelemetry.environment_variables import OTEL_LOGS_EXPORTER, OTEL_METRICS
 
 class AzureMonitorDistro(BaseDistro):
     def _configure(self, **kwargs):
-        environ.setdefault(OTEL_LOGS_EXPORTER, "otlp_proto_grpc")
-        environ.setdefault(OTEL_METRICS_EXPORTER, "otlp_proto_grpc")
-        environ.setdefault(OTEL_TRACES_EXPORTER, "otlp_proto_grpc")
+        environ.setdefault(OTEL_LOGS_EXPORTER, "azure_monitor_opentelemetry_exporter")
+        environ.setdefault(OTEL_METRICS_EXPORTER, "azure_monitor_opentelemetry_exporter")
+        environ.setdefault(OTEL_TRACES_EXPORTER, "azure_monitor_opentelemetry_exporter")

--- a/src/azure/monitor/opentelemetry/distro/distro.py
+++ b/src/azure/monitor/opentelemetry/distro/distro.py
@@ -6,10 +6,17 @@
 
 from os import environ
 from opentelemetry.instrumentation.distro import BaseDistro
-from opentelemetry.environment_variables import OTEL_LOGS_EXPORTER, OTEL_METRICS_EXPORTER, OTEL_TRACES_EXPORTER
+from opentelemetry.environment_variables import (
+    OTEL_LOGS_EXPORTER,
+    OTEL_METRICS_EXPORTER,
+    OTEL_TRACES_EXPORTER,
+)
+
 
 class AzureMonitorDistro(BaseDistro):
     def _configure(self, **kwargs):
         environ.setdefault(OTEL_LOGS_EXPORTER, "azure_monitor_opentelemetry_exporter")
-        environ.setdefault(OTEL_METRICS_EXPORTER, "azure_monitor_opentelemetry_exporter")
+        environ.setdefault(
+            OTEL_METRICS_EXPORTER, "azure_monitor_opentelemetry_exporter"
+        )
         environ.setdefault(OTEL_TRACES_EXPORTER, "azure_monitor_opentelemetry_exporter")

--- a/src/azure/monitor/opentelemetry/distro/distro.py
+++ b/src/azure/monitor/opentelemetry/distro/distro.py
@@ -6,8 +6,7 @@
 
 from os import environ
 
-from opentelemetry.environment_variables import (OTEL_LOGS_EXPORTER,
-                                                 OTEL_METRICS_EXPORTER,
+from opentelemetry.environment_variables import (OTEL_METRICS_EXPORTER,
                                                  OTEL_TRACES_EXPORTER)
 from opentelemetry.instrumentation.distro import BaseDistro
 

--- a/src/azure/monitor/opentelemetry/distro/distro.py
+++ b/src/azure/monitor/opentelemetry/distro/distro.py
@@ -14,7 +14,8 @@ from opentelemetry.instrumentation.distro import BaseDistro
 
 class AzureMonitorDistro(BaseDistro):
     def _configure(self, **kwargs):
-        environ.setdefault(OTEL_LOGS_EXPORTER, "azure_monitor_opentelemetry_exporter")
+        # TODO: Uncomment when logging is out of preview
+        # environ.setdefault(OTEL_LOGS_EXPORTER, "azure_monitor_opentelemetry_exporter")
         environ.setdefault(
             OTEL_METRICS_EXPORTER, "azure_monitor_opentelemetry_exporter"
         )

--- a/src/azure/monitor/opentelemetry/distro/distro.py
+++ b/src/azure/monitor/opentelemetry/distro/distro.py
@@ -1,0 +1,15 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+from os import environ
+from opentelemetry.instrumentation.distro import BaseDistro
+from opentelemetry.environment_variables import OTEL_LOGS_EXPORTER, OTEL_METRICS_EXPORTER, OTEL_TRACES_EXPORTER
+
+class AzureMonitorDistro(BaseDistro):
+    def _configure(self, **kwargs):
+        environ.setdefault(OTEL_LOGS_EXPORTER, "otlp_proto_grpc")
+        environ.setdefault(OTEL_METRICS_EXPORTER, "otlp_proto_grpc")
+        environ.setdefault(OTEL_TRACES_EXPORTER, "otlp_proto_grpc")

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,2 @@
 pytest
 azure-monitor-opentelemetry-exporter
-opentelemetry-api
-opentelemetry-instrumentation
-opentelemetry-sdk

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,5 @@
 pytest
 azure-monitor-opentelemetry-exporter
+opentelemetry-api
+opentelemetry-instrumentation
+opentelemetry-sdk

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
 pytest
-azure-monitor-opentelemetry-exporter

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,9 @@ recreate = True
 deps =
   -r lint-requirements.txt
 
+commands_pre = 
+  python -m pip install -e {toxinidir}
+
 commands =
   black src
   isort --recursive src


### PR DESCRIPTION
## Description
Added an OpenTelemetry Distro and an OpenTelemetry Configurator. These provide a way to customize auto-instrumentation. The distro sets the default exporters to the Azure Monitor exporters. The configurator does not currently add any additional functionality to the base OT configurator, but can be edited to do so in the future.

## Related PR
[This PR](https://github.com/Azure/azure-sdk-for-python/pull/25368) added the exporter entry points which enabled auto-instrumentation to access the exporters. Since this PR includes using those exporters as the default, auto-instrumentation will only work properly when your version of exporters include the addition of the entry points.

## Testing
Testing by pointing to a version of the azure-monitor-opentelemetry-exporter with the entry points and triggering auto-instrumentation. Spans were created successfully.