### PR TITLE
Defaulting logging env var. Added logging samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
     ([#235](https://github.com/microsoft/ApplicationInsights-Python/pull/235))
 - Fix export interval bug
     ([#237](https://github.com/microsoft/ApplicationInsights-Python/pull/237))
+- Defaulting logging env var for auto-instrumentation. Added logging samples.
+    ([#240](https://github.com/microsoft/ApplicationInsights-Python/pull/240))
 
 ## [1.0.0b8](https://github.com/microsoft/ApplicationInsights-Python/releases/tag/v1.0.0b8) - 2022-09-26
 

--- a/azure-monitor-opentelemetry-distro/README.md
+++ b/azure-monitor-opentelemetry-distro/README.md
@@ -49,7 +49,7 @@ You can use `configure_azure_monitor` to set up instrumentation for your app to 
 * disable_logging - If set to `True`, disables collection and export of logging telemetry.
 * disable_metrics - If set to `True`, disables collection and export of metric telemetry.
 * disable_tracing - If set to `True`, disables collection and export of distributed tracing telemetry.
-* logging_level - Specifies the [logging level][logging_level] of the Opentelemetry Logging Handler. Ex: logging.WARNING.
+* logging_level - Specifies the [logging level][logging_level] of the Opentelemetry Logging Handler. Defaults to logging.NOTSET.
 * logger_name = Specifies the [logger name][logger_name_hierarchy_doc] under which all logging will be instrumented. Defaults to "" which corresponds to the root logger.
 * logging_export_interval_millis - Specifies the logging export interval in milliseconds. Defaults to 5000.
 * views - Specifies the list of [views][opentelemetry_specification_view] to configure for the metric pipeline. See [here][ot_sdk_python_view_examples] for example usage.

--- a/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/distro.py
+++ b/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/distro.py
@@ -18,6 +18,9 @@ from opentelemetry.environment_variables import (
     OTEL_TRACES_EXPORTER,
 )
 from opentelemetry.instrumentation.distro import BaseDistro
+from opentelemetry.sdk.environment_variables import (
+    _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED,
+)
 
 _logger = logging.getLogger(__name__)
 _opentelemetry_logger = logging.getLogger("opentelemetry")
@@ -58,6 +61,9 @@ def _configure_auto_instrumentation() -> None:
         )
         environ.setdefault(
             OTEL_LOGS_EXPORTER, "azure_monitor_opentelemetry_exporter"
+        )
+        environ.setdefault(
+            _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED, "true"
         )
         AzureStatusLogger.log_status(True)
         _logger.info(

--- a/azure-monitor-opentelemetry-distro/samples/logging/correlated_logs.py
+++ b/azure-monitor-opentelemetry-distro/samples/logging/correlated_logs.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from logging import WARN, getLogger
+from logging import WARNING, getLogger
 
 from azure.monitor.opentelemetry.distro import configure_azure_monitor
 from opentelemetry import trace
@@ -12,13 +12,17 @@ from opentelemetry import trace
 configure_azure_monitor(
     connection_string="<your-connection-string>",
     service_name="foo_service",
-    logging_level=WARN,
+    logging_level=WARNING,
     disable_metrics=True,
     disable_tracing=True,
 )
 
 logger = getLogger(__name__)
 tracer = trace.get_tracer(__name__)
+
+logger.info("Uncorrelated info log")
+logger.warning("Uncorrelated warning log")
+logger.error("Uncorrelated error log")
 
 with tracer.start_as_current_span("Span for correlated logs"):
     logger.info("Correlated info log")

--- a/azure-monitor-opentelemetry-distro/samples/logging/correlated_logs.py
+++ b/azure-monitor-opentelemetry-distro/samples/logging/correlated_logs.py
@@ -7,6 +7,7 @@
 from logging import WARN, getLogger
 
 from azure.monitor.opentelemetry.distro import configure_azure_monitor
+from opentelemetry import trace
 
 configure_azure_monitor(
     connection_string="<your-connection-string>",
@@ -17,7 +18,9 @@ configure_azure_monitor(
 )
 
 logger = getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
-logger.info("info log")
-logger.warning("warning log")
-logger.error("error log")
+with tracer.start_as_current_span("Span for correlated logs"):
+    logger.info("Correlated info log")
+    logger.warning("Correlated warning log")
+    logger.error("Correlated error log")

--- a/azure-monitor-opentelemetry-distro/samples/logging/custom_properties.py
+++ b/azure-monitor-opentelemetry-distro/samples/logging/custom_properties.py
@@ -20,4 +20,5 @@ configure_azure_monitor(
 logger = getLogger(__name__)
 logger.setLevel(DEBUG)
 
+# Pass custom properties in a dictionary with the extra argument
 logger.debug("DEBUG: Debug with properties", extra={"debug": "true"})

--- a/azure-monitor-opentelemetry-distro/samples/logging/custom_properties.py
+++ b/azure-monitor-opentelemetry-distro/samples/logging/custom_properties.py
@@ -4,20 +4,20 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from logging import WARN, getLogger
+from logging import DEBUG, getLogger
 
 from azure.monitor.opentelemetry.distro import configure_azure_monitor
 
 configure_azure_monitor(
     connection_string="<your-connection-string>",
     service_name="foo_service",
-    logging_level=WARN,
+    logger_name=__name__,
+    logging_level=DEBUG,
     disable_metrics=True,
     disable_tracing=True,
 )
 
 logger = getLogger(__name__)
+logger.setLevel(DEBUG)
 
-logger.info("info log")
-logger.warning("warning log")
-logger.error("error log")
+logger.debug("DEBUG: Debug with properties", extra={"debug": "true"})

--- a/azure-monitor-opentelemetry-distro/samples/logging/exception_logs.py
+++ b/azure-monitor-opentelemetry-distro/samples/logging/exception_logs.py
@@ -18,6 +18,16 @@ configure_azure_monitor(
 
 logger = getLogger(__name__)
 
-logger.info("info log")
-logger.warning("warning log")
-logger.error("error log")
+# The following code will generate two pieces of exception telemetry
+# that are identical in nature
+try:
+    val = 1 / 0
+    print(val)
+except ZeroDivisionError:
+    logger.exception("Error: Division by zero")
+
+try:
+    val = 1 / 0
+    print(val)
+except ZeroDivisionError:
+    logger.error("Error: Division by zero", stack_info=True, exc_info=True)

--- a/azure-monitor-opentelemetry-distro/samples/logging/exception_logs.py
+++ b/azure-monitor-opentelemetry-distro/samples/logging/exception_logs.py
@@ -4,14 +4,14 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from logging import WARN, getLogger
+from logging import WARNING, getLogger
 
 from azure.monitor.opentelemetry.distro import configure_azure_monitor
 
 configure_azure_monitor(
     connection_string="<your-connection-string>",
     service_name="foo_service",
-    logging_level=WARN,
+    logging_level=WARNING,
     disable_metrics=True,
     disable_tracing=True,
 )

--- a/azure-monitor-opentelemetry-distro/samples/logging/logs_with_traces.py
+++ b/azure-monitor-opentelemetry-distro/samples/logging/logs_with_traces.py
@@ -1,0 +1,53 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+from logging import WARN, getLogger
+
+import flask
+from azure.monitor.opentelemetry.distro import configure_azure_monitor
+from opentelemetry import trace
+
+configure_azure_monitor(
+    connection_string="<your-connection-string>",
+    service_name="flask_service_name",
+    logging_level=WARN,
+    disable_metrics=True,
+    instrumentations=["flask"],
+    tracing_export_interval_millis=15000,
+)
+
+logger = getLogger(__name__)
+
+app = flask.Flask(__name__)
+
+
+@app.route("/info_log")
+def info_log():
+    message = "Correlated info log"
+    logger.info(message)
+    return message
+
+
+@app.route("/error_log")
+def error_log():
+    message = "Correlated error log"
+    logger.error(message)
+    return message
+
+
+@app.route("/error_log")
+def error_log():
+    message = "Correlated error log"
+    logger.error(message)
+    return message
+
+
+if __name__ == "__main__":
+    app.run(host="localhost", port=8080)
+
+    logger.info("Correlated info log")
+    logger.warning("Correlated warning log")
+    logger.error("Correlated error log")

--- a/azure-monitor-opentelemetry-distro/samples/logging/logs_with_traces.py
+++ b/azure-monitor-opentelemetry-distro/samples/logging/logs_with_traces.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from logging import WARN, getLogger
+from logging import WARNING, getLogger
 
 import flask
 from azure.monitor.opentelemetry.distro import configure_azure_monitor
@@ -13,7 +13,7 @@ from opentelemetry import trace
 configure_azure_monitor(
     connection_string="<your-connection-string>",
     service_name="flask_service_name",
-    logging_level=WARN,
+    logging_level=WARNING,
     disable_metrics=True,
     instrumentations=["flask"],
     tracing_export_interval_millis=15000,

--- a/azure-monitor-opentelemetry-distro/samples/logging/simple.py
+++ b/azure-monitor-opentelemetry-distro/samples/logging/simple.py
@@ -4,14 +4,14 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from logging import WARN, getLogger
+from logging import WARNING, getLogger
 
 from azure.monitor.opentelemetry.distro import configure_azure_monitor
 
 configure_azure_monitor(
     connection_string="<your-connection-string>",
     service_name="foo_service",
-    logging_level=WARN,
+    logging_level=WARNING,
     disable_metrics=True,
     disable_tracing=True,
 )


### PR DESCRIPTION
 * Defaulting _OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED to true for auto-instrumentation.
 * Added samples for correlated logs, exceptions, and custom properties
 * Updated readme with logging_level defaulting behavior.
Fixes https://github.com/microsoft/ApplicationInsights-Python/issues/239