### PR TITLE
Add ability to add custom span processors and metric readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
     ([#235](https://github.com/microsoft/ApplicationInsights-Python/pull/235))
 - Fix export interval bug
     ([#237](https://github.com/microsoft/ApplicationInsights-Python/pull/237))
+- Add ability to specify custom span processors and metric readers
+    ([#237](https://github.com/microsoft/ApplicationInsights-Python/pull/237))
 
 ## [1.0.0b8](https://github.com/microsoft/ApplicationInsights-Python/releases/tag/v1.0.0b8) - 2022-09-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
     ([#235](https://github.com/microsoft/ApplicationInsights-Python/pull/235))
 - Fix export interval bug
     ([#237](https://github.com/microsoft/ApplicationInsights-Python/pull/237))
-- Add ability to specify custom span processors and metric readers
+- Add ability to specify custom metric readers
     ([#241](https://github.com/microsoft/ApplicationInsights-Python/pull/241))
 
 ## [1.0.0b8](https://github.com/microsoft/ApplicationInsights-Python/releases/tag/v1.0.0b8) - 2022-09-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Fix export interval bug
     ([#237](https://github.com/microsoft/ApplicationInsights-Python/pull/237))
 - Add ability to specify custom span processors and metric readers
-    ([#237](https://github.com/microsoft/ApplicationInsights-Python/pull/237))
+    ([#241](https://github.com/microsoft/ApplicationInsights-Python/pull/241))
 
 ## [1.0.0b8](https://github.com/microsoft/ApplicationInsights-Python/releases/tag/v1.0.0b8) - 2022-09-26
 

--- a/azure-monitor-opentelemetry-distro/README.md
+++ b/azure-monitor-opentelemetry-distro/README.md
@@ -52,11 +52,10 @@ You can use `configure_azure_monitor` to set up instrumentation for your app to 
 * logging_level - Specifies the [logging level][logging_level] of the Opentelemetry Logging Handler. Ex: logging.WARNING.
 * logger_name = Specifies the [logger name][logger_name_hierarchy_doc] under which all logging will be instrumented. Defaults to "" which corresponds to the root logger.
 * logging_export_interval_millis - Specifies the logging export interval in milliseconds. Defaults to 5000.
+* metric_readers - Specifies the [metric readers][ot_metric_reader] that you would like to use for your metrics pipeline. Accepts a list of [metric readers][ot_sdk_python_metric_reader].
 * views - Specifies the list of [views][opentelemetry_specification_view] to configure for the metric pipeline. See [here][ot_sdk_python_view_examples] for example usage.
 * sampling_ratio - Specifies the ratio of distributed tracing telemetry to be [sampled][application_insights_sampling]. Accepted values are in the range [0,1]. Defaults to 1.0, meaning no telemetry is sampled out.
 * tracing_export_interval_millis - Specifies the distributed tracing export interval in milliseconds. Defaults to 5000.
-* metric_readers - Specifies the [metric readers][ot_metric_reader] that you would like to use for your tracing pipeline. Accepts a list of [metric readers][ot_sdk_python_metric_reader].
-* span_processors - Specifies the [span processors][ot_span_processor] that you would like to use for your tracing pipeline. Accepts a list of [span processors][ot_sdk_python_span_processor].
 
 #### Exporter configurations
 
@@ -112,9 +111,7 @@ Samples are available [here][samples] to demonstrate how to utilize the above co
 [ot_python_docs]: https://opentelemetry.io/docs/instrumentation/python/
 [ot_sdk_python]: https://github.com/open-telemetry/opentelemetry-python
 [ot_sdk_python_metric_reader]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/metrics.export.html#opentelemetry.sdk.metrics.export.MetricReader
-[ot_sdk_python_span_processor]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/trace.html#opentelemetry.sdk.trace.SpanProcessor
 [ot_sdk_python_view_examples]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/metrics/views
-[ot_span_processor]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-processor
 [opentelemetry_instrumentation_requests]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-requests
 [opentelemetry_instrumentation_django]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-django
 [opentelemetry_instrumentation_flask]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-flask

--- a/azure-monitor-opentelemetry-distro/README.md
+++ b/azure-monitor-opentelemetry-distro/README.md
@@ -55,6 +55,8 @@ You can use `configure_azure_monitor` to set up instrumentation for your app to 
 * views - Specifies the list of [views][opentelemetry_specification_view] to configure for the metric pipeline. See [here][ot_sdk_python_view_examples] for example usage.
 * sampling_ratio - Specifies the ratio of distributed tracing telemetry to be [sampled][application_insights_sampling]. Accepted values are in the range [0,1]. Defaults to 1.0, meaning no telemetry is sampled out.
 * tracing_export_interval_millis - Specifies the distributed tracing export interval in milliseconds. Defaults to 5000.
+* metric_readers - Specifies the [metric readers][ot_metric_reader] that you would like to use for your tracing pipeline. Accepts a list of [metric readers][ot_sdk_python_metric_reader].
+* span_processors - Specifies the [span processors][ot_span_processor] that you would like to use for your tracing pipeline. Accepts a list of [span processors][ot_sdk_python_span_processor].
 
 #### Exporter configurations
 
@@ -106,9 +108,13 @@ Samples are available [here][samples] to demonstrate how to utilize the above co
 [logging_level]: https://docs.python.org/3/library/logging.html#levels
 [logger_name_hierarchy_doc]: https://docs.python.org/3/library/logging.html#logger-objects
 [ot_instrumentations]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation
+[ot_metric_reader]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#metricreader
 [ot_python_docs]: https://opentelemetry.io/docs/instrumentation/python/
 [ot_sdk_python]: https://github.com/open-telemetry/opentelemetry-python
+[ot_sdk_python_metric_reader]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/metrics.export.html#opentelemetry.sdk.metrics.export.MetricReader
+[ot_sdk_python_span_processor]: https://opentelemetry-python.readthedocs.io/en/stable/sdk/trace.html#opentelemetry.sdk.trace.SpanProcessor
 [ot_sdk_python_view_examples]: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs/examples/metrics/views
+[ot_span_processor]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#span-processor
 [opentelemetry_instrumentation_requests]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-requests
 [opentelemetry_instrumentation_django]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-django
 [opentelemetry_instrumentation_flask]: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-flask

--- a/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/__init__.py
+++ b/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/__init__.py
@@ -92,6 +92,7 @@ def _get_resource(configurations: Dict[str, Any]) -> Resource:
 
 def _setup_tracing(resource: Resource, configurations: Dict[str, Any]):
     sampling_ratio = configurations.get("sampling_ratio", 1.0)
+    span_processors = configurations.get("span_processors", [])
     tracing_export_interval_millis = configurations.get(
         "tracing_export_interval_millis", 5000
     )
@@ -106,6 +107,8 @@ def _setup_tracing(resource: Resource, configurations: Dict[str, Any]):
         schedule_delay_millis=tracing_export_interval_millis,
     )
     get_tracer_provider().add_span_processor(span_processor)
+    for sp in span_processors:
+        get_tracer_provider().add_span_processor(sp)
 
 
 def _setup_logging(resource: Resource, configurations: Dict[str, Any]):
@@ -130,10 +133,11 @@ def _setup_logging(resource: Resource, configurations: Dict[str, Any]):
 
 def _setup_metrics(resource: Resource, configurations: Dict[str, Any]):
     views = configurations.get("views", ())
+    metric_readers = configurations.get("metric_readers", [])
     metric_exporter = AzureMonitorMetricExporter(**configurations)
     reader = PeriodicExportingMetricReader(metric_exporter)
     meter_provider = MeterProvider(
-        metric_readers=[reader],
+        metric_readers=[reader] + metric_readers,
         resource=resource,
         views=views,
     )

--- a/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/__init__.py
+++ b/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/__init__.py
@@ -92,7 +92,6 @@ def _get_resource(configurations: Dict[str, Any]) -> Resource:
 
 def _setup_tracing(resource: Resource, configurations: Dict[str, Any]):
     sampling_ratio = configurations.get("sampling_ratio", 1.0)
-    span_processors = configurations.get("span_processors", [])
     tracing_export_interval_millis = configurations.get(
         "tracing_export_interval_millis", 5000
     )
@@ -107,8 +106,6 @@ def _setup_tracing(resource: Resource, configurations: Dict[str, Any]):
         schedule_delay_millis=tracing_export_interval_millis,
     )
     get_tracer_provider().add_span_processor(span_processor)
-    for sp in span_processors:
-        get_tracer_provider().add_span_processor(sp)
 
 
 def _setup_logging(resource: Resource, configurations: Dict[str, Any]):

--- a/azure-monitor-opentelemetry-distro/tests/configuration/test_configure.py
+++ b/azure-monitor-opentelemetry-distro/tests/configuration/test_configure.py
@@ -64,7 +64,6 @@ class TestConfigure(unittest.TestCase):
             "service_namespace": "test_namespace",
             "service_instance_id": "test_id",
             "sampling_ratio": 0.5,
-            "span_processors": "test_span_processors",
             "tracing_export_interval_millis": 15000,
             "views": "test_views",
         }
@@ -278,7 +277,6 @@ class TestConfigure(unittest.TestCase):
             "connection_string": "test_cs",
             "disable_tracing": False,
             "sampling_ratio": 0.5,
-            "span_processors": ["test_processor1", "test_processor2"],
             "tracing_export_interval_millis": 15000,
         }
         _setup_tracing(resource_mock, configurations)
@@ -293,13 +291,7 @@ class TestConfigure(unittest.TestCase):
         bsp_mock.assert_called_once_with(
             trace_exp_init_mock, schedule_delay_millis=15000
         )
-        tp_init_mock.add_span_processor.assert_has_calls(
-            [
-                call(bsp_init_mock),
-                call("test_processor1"),
-                call("test_processor2"),
-            ]
-        )
+        tp_init_mock.add_span_processor.assert_called_once_with(bsp_init_mock)
 
     @patch(
         "azure.monitor.opentelemetry.distro.getLogger",

--- a/azure-monitor-opentelemetry-distro/tests/configuration/test_configure.py
+++ b/azure-monitor-opentelemetry-distro/tests/configuration/test_configure.py
@@ -59,10 +59,12 @@ class TestConfigure(unittest.TestCase):
             "logging_export_interval_millis": 10000,
             "logging_level": "test_logging_level",
             "logger_name": "test_logger_name",
+            "metric_readers": "test_metric_readers",
             "service_name": "test_service_name",
             "service_namespace": "test_namespace",
             "service_instance_id": "test_id",
             "sampling_ratio": 0.5,
+            "span_processors": "test_span_processors",
             "tracing_export_interval_millis": 15000,
             "views": "test_views",
         }
@@ -276,6 +278,7 @@ class TestConfigure(unittest.TestCase):
             "connection_string": "test_cs",
             "disable_tracing": False,
             "sampling_ratio": 0.5,
+            "span_processors": ["test_processor1", "test_processor2"],
             "tracing_export_interval_millis": 15000,
         }
         _setup_tracing(resource_mock, configurations)
@@ -290,7 +293,13 @@ class TestConfigure(unittest.TestCase):
         bsp_mock.assert_called_once_with(
             trace_exp_init_mock, schedule_delay_millis=15000
         )
-        tp_init_mock.add_span_processor(bsp_init_mock)
+        tp_init_mock.add_span_processor.assert_has_calls(
+            [
+                call(bsp_init_mock),
+                call("test_processor1"),
+                call("test_processor2"),
+            ]
+        )
 
     @patch(
         "azure.monitor.opentelemetry.distro.getLogger",
@@ -396,11 +405,12 @@ class TestConfigure(unittest.TestCase):
         configurations = {
             "connection_string": "test_cs",
             "disable_metrics": False,
+            "metric_readers": ["test_reader1", "test_reader2"],
             "views": "test_views",
         }
         _setup_metrics(resource_mock, configurations)
         mp_mock.assert_called_once_with(
-            metric_readers=[reader_init_mock],
+            metric_readers=[reader_init_mock, "test_reader1", "test_reader2"],
             resource=resource_mock,
             views="test_views",
         )

--- a/azure-monitor-opentelemetry-distro/tests/configuration/test_util.py
+++ b/azure-monitor-opentelemetry-distro/tests/configuration/test_util.py
@@ -32,6 +32,7 @@ class TestUtil(unittest.TestCase):
             sampling_ratio="test_sample_ratio",
             tracing_export_interval="test_tracing_interval",
             logging_export_interval="test_logging_interval",
+            metric_readers=("test_readers"),
             views=("test_view"),
         )
 
@@ -57,4 +58,5 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(
             configurations["logging_export_interval"], "test_logging_interval"
         )
+        self.assertEqual(configurations["metric_readers"], ("test_readers"))
         self.assertEqual(configurations["views"], ("test_view"))


### PR DESCRIPTION
Note we did not include configuring `LogRecordProcessor`s because logging is unstable. Asking the user to specify those classes may induce breaking changes.

Fixes https://github.com/microsoft/ApplicationInsights-Python/issues/236