### PR TITLE
Update to exporter 1.0.0b12 and sdk/api 1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
     ([#240](https://github.com/microsoft/ApplicationInsights-Python/pull/240))
 - Removed old log_diagnostic_error calls from configurator
     ([#242](https://github.com/microsoft/ApplicationInsights-Python/pull/242))
+- Update to azure-monitor-opentelemetry-exporter 1.0.0b12
+    ([#243](https://github.com/microsoft/ApplicationInsights-Python/pull/243))
 
 ## [1.0.0b8](https://github.com/microsoft/ApplicationInsights-Python/releases/tag/v1.0.0b8) - 2022-09-26
 

--- a/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/__init__.py
+++ b/azure-monitor-opentelemetry-distro/azure/monitor/opentelemetry/distro/__init__.py
@@ -14,13 +14,9 @@ from azure.monitor.opentelemetry.exporter import (
     AzureMonitorMetricExporter,
     AzureMonitorTraceExporter,
 )
+from opentelemetry._logs import get_logger_provider, set_logger_provider
 from opentelemetry.metrics import set_meter_provider
-from opentelemetry.sdk._logs import (
-    LoggerProvider,
-    LoggingHandler,
-    get_logger_provider,
-    set_logger_provider,
-)
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader

--- a/azure-monitor-opentelemetry-distro/setup.py
+++ b/azure-monitor-opentelemetry-distro/setup.py
@@ -85,12 +85,12 @@ setup(
     },
     python_requires=">=3.7",
     install_requires=[
-        "azure-monitor-opentelemetry-exporter>=1.0.0b11",
-        "opentelemetry-instrumentation~=0.35b0",
-        "opentelemetry-instrumentation-django~=0.35b0",
-        "opentelemetry-instrumentation-requests~=0.35b0",
-        "opentelemetry-instrumentation-flask~=0.35b0",
-        "opentelemetry-instrumentation-psycopg2~=0.35b0",
+        "azure-monitor-opentelemetry-exporter>=1.0.0b12",
+        "opentelemetry-instrumentation~=0.36b0",
+        "opentelemetry-instrumentation-django~=0.36b0",
+        "opentelemetry-instrumentation-requests~=0.36b0",
+        "opentelemetry-instrumentation-flask~=0.36b0",
+        "opentelemetry-instrumentation-psycopg2~=0.36b0",
     ],
     entry_points={
         "opentelemetry_distro": [


### PR DESCRIPTION
Updating to the latest exporter and api/sdk.

This comes with the warning mentioned in this issue: https://github.com/open-telemetry/opentelemetry-python/issues/3102