### PR TITLE
Fix source and wheel distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix source and wheel distribution, include MANIFEST.in and use `pkgutils` style `__init__.py`
+    ([#250](https://github.com/microsoft/ApplicationInsights-Python/pull/250))
+
 ## [1.0.0b9](https://github.com/microsoft/ApplicationInsights-Python/releases/tag/v1.0.0b9) - 2023-02-22
 
 - Made build.sh script executable from publish workflow

--- a/azure-monitor-opentelemetry/LICENSE
+++ b/azure-monitor-opentelemetry/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/azure-monitor-opentelemetry/MANIFEST.in
+++ b/azure-monitor-opentelemetry/MANIFEST.in
@@ -1,0 +1,10 @@
+include *.md
+include azure/__init__.py
+include azure/monitor/__init__.py
+include LICENSE
+recursive-include tests *.py
+recursive-include samples *.py *.md
+include azure/monitor/opentelemetry/py.typed
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude __pycache__/*

--- a/azure-monitor-opentelemetry/azure/__init__.py
+++ b/azure-monitor-opentelemetry/azure/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/azure-monitor-opentelemetry/azure/__init__.py
+++ b/azure-monitor-opentelemetry/azure/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/azure-monitor-opentelemetry/azure/monitor/__init__.py
+++ b/azure-monitor-opentelemetry/azure/monitor/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)

--- a/azure-monitor-opentelemetry/azure/monitor/__init__.py
+++ b/azure-monitor-opentelemetry/azure/monitor/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
MANIFEST.in is responsible for specifying files in source distribution.
LICENSE file was missing.
Modify `__init__.py` to use `pkgutil` method since exclusion of packages in `setup.py` (azure-sdk does this for some reason so we have to follow suit for now until we switch to namespace packages)