### PR TITLE
Change default behavior of instrumentations and implement exclusion configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Reverse default behavior of instrumentations and implement configuration for exclusion
-    ([#250](https://github.com/microsoft/ApplicationInsights-Python/pull/250))
+    ([#253](https://github.com/microsoft/ApplicationInsights-Python/pull/253))
 
 ## [1.0.0b10](https://github.com/microsoft/ApplicationInsights-Python/releases/tag/v1.0.0b10) - 2023-02-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Reverse default behavior of instrumentations and implement configuration for exclusion
+    ([#250](https://github.com/microsoft/ApplicationInsights-Python/pull/250))
+
 ## [1.0.0b10](https://github.com/microsoft/ApplicationInsights-Python/releases/tag/v1.0.0b10) - 2023-02-23
 
 - Fix source and wheel distribution, include MANIFEST.in and use `pkgutils` style `__init__.py`

--- a/azure-monitor-opentelemetry/README.md
+++ b/azure-monitor-opentelemetry/README.md
@@ -5,6 +5,11 @@ The Azure Monitor Distro of [Opentelemetry Python][ot_sdk_python] provides multi
 This distro automatically installs the following libraries:
 
 * [Azure Monitor OpenTelemetry exporters][azure_monitor_opentelemetry_exporters]
+
+## Officially supported instrumentations
+
+The following OpenTelemetry instrumentations come bundled in with the Azure monitor distro. If you would like to add support for another OpenTelemetry instrumentation, please submit a feature [request][distro_feature_request]. In the meantime, you can use the OpenTelemetry instrumentation manually via it's own APIs (i.e. `instrument()`) in your code.
+
 * [OpenTelemetry Requests Instrumentation][opentelemetry_instrumentation_requests]
 * [OpenTelemetry Django Instrumentation][opentelemetry_instrumentation_django]
 * [OpenTelemetry Flask Instrumentation][opentelemetry_instrumentation_flask]
@@ -46,6 +51,7 @@ You can use `configure_azure_monitor` to set up instrumentation for your app to 
 * disable_logging - If set to `True`, disables collection and export of logging telemetry. Defaults to `False`.
 * disable_metrics - If set to `True`, disables collection and export of metric telemetry. Defaults to `False`.
 * disable_tracing - If set to `True`, disables collection and export of distributed tracing telemetry. Defaults to `False`.
+* exclude_instrumentations - By default, all supported [instrumentations](#officially-supported-instrumentations) are enabled to collect telemetry. Specify instrumentations you do not want to enable to collect telemetry by passing in a comma separated list of instrumented library names. e.g. `["requests", "flask"]`
 * resource - Specified the OpenTelemetry [resource][opentelemetry_spec_resource] associated with your application. See [this][ot_sdk_python_resource] for default behavior.
 * logging_level - Specifies the [logging level][logging_level] of the logs you would like to collect for your logging pipeline. Defaults to logging.NOTSET.
 * logger_name = Specifies the [logger name][logger_name_hierarchy_doc] under which logging will be instrumented. Defaults to "" which corresponds to the root logger.
@@ -101,6 +107,7 @@ Samples are available [here][samples] to demonstrate how to utilize the above co
 [application_insights_namespace]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
 [application_insights_sampling]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/sampling
 [connection_string_doc]: https://learn.microsoft.com/en-us/azure/azure-monitor/app/sdk-connection-string
+[distro_feature_request]: https://github.com/microsoft/ApplicationInsights-Python/issues/new
 [exporter_configuration_docs]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/monitor/azure-monitor-opentelemetry-exporter#configuration
 [logging_level]: https://docs.python.org/3/library/logging.html#levels
 [logger_name_hierarchy_doc]: https://docs.python.org/3/library/logging.html#logger-objects

--- a/azure-monitor-opentelemetry/README.md
+++ b/azure-monitor-opentelemetry/README.md
@@ -47,7 +47,6 @@ pip install azure-monitor-opentelemetry --pre
 You can use `configure_azure_monitor` to set up instrumentation for your app to Azure Monitor. `configure_azure_monitor` supports the following optional arguments:
 
 * connection_string - The [connection string][connection_string_doc] for your Application Insights resource. The connection string will be automatically populated from the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable if not explicitly passed in.
-* instrumentations - Specifies the libraries with [instrumentations][ot_instrumentations] that you would like to use. Accepts a comma separated list. e.g. `["requests", "flask"]`
 * disable_logging - If set to `True`, disables collection and export of logging telemetry. Defaults to `False`.
 * disable_metrics - If set to `True`, disables collection and export of metric telemetry. Defaults to `False`.
 * disable_tracing - If set to `True`, disables collection and export of distributed tracing telemetry. Defaults to `False`.

--- a/azure-monitor-opentelemetry/README.md
+++ b/azure-monitor-opentelemetry/README.md
@@ -75,13 +75,12 @@ configure_azure_monitor(
 
 #### Instrumentation configurations
 
-You can pass in instrumentation specific configuration into `configure_azure_monitor` with the key `<instrumented-library-name>_config` and value as a dictionary representing `kwargs` for the corresponding instrumentation. Note the instrumented library must also be enabled through the `instrumentations` configuration.
+You can pass in instrumentation specific configuration into `configure_azure_monitor` with the key `<instrumented-library-name>_config` and value as a dictionary representing `kwargs` for the corresponding instrumentation.
 
 ```python
 ...
 configure_azure_monitor(
     connection_string="<your-connection-string>",
-    instrumentations=["flask", "requests"],
     flask_config={"excluded_urls": "http://localhost:8080/ignore"},
     requests_config={"excluded_urls": "http://example.com"},
 )

--- a/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
+++ b/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_configure.py
@@ -14,7 +14,7 @@ from azure.monitor.opentelemetry.exporter import (
     AzureMonitorMetricExporter,
     AzureMonitorTraceExporter,
 )
-from azure.monitor.opentelemetry.util import _get_configurations
+from azure.monitor.opentelemetry.util.configurations import _get_configurations
 from opentelemetry._logs import get_logger_provider, set_logger_provider
 from opentelemetry.metrics import set_meter_provider
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
@@ -152,7 +152,9 @@ def _setup_metrics(
 
 
 def _setup_instrumentations(configurations: Dict[str, ConfigurationValue]):
-    instrumentations = configurations.get("instrumentations", [])
+    exclude_instrumentations = configurations.get(
+        "exclude_instrumentations", []
+    )
     instrumentation_configs = {}
 
     # Instrumentation specific configs
@@ -162,37 +164,35 @@ def _setup_instrumentations(configurations: Dict[str, ConfigurationValue]):
             lib_name = k.partition(_INSTRUMENTATION_CONFIG_SUFFIX)[0]
             instrumentation_configs[lib_name] = v
 
-    for lib_name in instrumentations:
-        if lib_name in _SUPPORTED_INSTRUMENTED_LIBRARIES:
-            try:
-                importlib.import_module(lib_name)
-            except ImportError:
-                _logger.warning(
-                    "Unable to import %s. Please make sure it is installed.",
-                    lib_name,
-                )
-                continue
-            instr_lib_name = "opentelemetry.instrumentation." + lib_name
-            try:
-                module = importlib.import_module(instr_lib_name)
-                instrumentor_name = "{}Instrumentor".format(
-                    lib_name.capitalize()
-                )
-                class_ = getattr(module, instrumentor_name)
-                config = instrumentation_configs.get(lib_name, {})
-                class_().instrument(**config)
-            except ImportError:
-                _logger.warning(
-                    "Unable to import %s. Please make sure it is installed.",
-                    instr_lib_name,
-                )
-            except Exception as ex:
-                _logger.warning(
-                    "Exception occured when instrumenting: %s.",
-                    lib_name,
-                    exc_info=ex,
-                )
-        else:
+    for lib_name in _SUPPORTED_INSTRUMENTED_LIBRARIES:
+        if lib_name in exclude_instrumentations:
+            _logger.debug("Instrumentation skipped for library %s", lib_name)
+            continue
+        # Check if library is installed
+        try:
+            importlib.import_module(lib_name)
+        except ImportError:
             _logger.warning(
-                "Instrumentation not supported for library: %s.", lib_name
+                "Unable to import %s. Please make sure it is installed.",
+                lib_name,
+            )
+            continue
+        instr_lib_name = "opentelemetry.instrumentation." + lib_name
+        # Import and instrument the instrumentation
+        try:
+            module = importlib.import_module(instr_lib_name)
+            instrumentor_name = "{}Instrumentor".format(lib_name.capitalize())
+            class_ = getattr(module, instrumentor_name)
+            config = instrumentation_configs.get(lib_name, {})
+            class_().instrument(**config)
+        except ImportError:
+            _logger.warning(
+                "Unable to import %s. Please make sure it is installed.",
+                instr_lib_name,
+            )
+        except Exception as ex:
+            _logger.warning(
+                "Exception occured when instrumenting: %s.",
+                lib_name,
+                exc_info=ex,
             )

--- a/azure-monitor-opentelemetry/azure/monitor/opentelemetry/autoinstrumentation/_distro.py
+++ b/azure-monitor-opentelemetry/azure/monitor/opentelemetry/autoinstrumentation/_distro.py
@@ -50,9 +50,6 @@ def _configure_auto_instrumentation() -> None:
         #         "azure.monitor.opentelemetry.exporter"
         #     )
         #     AzureDiagnosticLogging.enable(_exporter_logger)
-        # TODO: Uncomment when logging is out of preview
-        # environ.setdefault(OTEL_LOGS_EXPORTER,
-        #     "azure_monitor_opentelemetry_exporter")
         environ.setdefault(
             OTEL_METRICS_EXPORTER, "azure_monitor_opentelemetry_exporter"
         )

--- a/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/__init__.py
+++ b/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/__init__.py
@@ -3,19 +3,3 @@
 # Licensed under the MIT License. See License in the project root for
 # license information.
 # --------------------------------------------------------------------------
-
-from typing import Dict
-
-from azure.monitor.opentelemetry._types import ConfigurationValue
-
-
-def _get_configurations(**kwargs) -> Dict[str, ConfigurationValue]:
-    configurations = {}
-
-    for key, val in kwargs.items():
-        configurations[key] = val
-
-    return configurations
-
-
-# TODO: Add env var configuration

--- a/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/configurations.py
+++ b/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/configurations.py
@@ -1,0 +1,21 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+from typing import Dict
+
+from azure.monitor.opentelemetry._types import ConfigurationValue
+
+
+def _get_configurations(**kwargs) -> Dict[str, ConfigurationValue]:
+    configurations = {}
+
+    for key, val in kwargs.items():
+        configurations[key] = val
+
+    return configurations
+
+
+# TODO: Add env var configuration

--- a/azure-monitor-opentelemetry/samples/tracing/db_psycopg2.py
+++ b/azure-monitor-opentelemetry/samples/tracing/db_psycopg2.py
@@ -11,7 +11,6 @@ configure_azure_monitor(
     connection_string="<your-connection-string>",
     disable_logging=True,
     disable_metrics=True,
-    instrumentations=["psycopg2"],
     tracing_export_interval_millis=15000,
 )
 

--- a/azure-monitor-opentelemetry/samples/tracing/django/sample/example/views.py
+++ b/azure-monitor-opentelemetry/samples/tracing/django/sample/example/views.py
@@ -10,7 +10,6 @@ from django.http import HttpResponse
 # Configure Azure monitor collection telemetry pipeline
 configure_azure_monitor(
     connection_string="<your-connection-string>",
-    instrumentations=["django"],
     disable_logging=True,
     disable_metrics=True,
     tracing_export_interval_millis=15000,

--- a/azure-monitor-opentelemetry/samples/tracing/http_flask.py
+++ b/azure-monitor-opentelemetry/samples/tracing/http_flask.py
@@ -11,7 +11,6 @@ configure_azure_monitor(
     connection_string="<your-connection-string>",
     disable_logging=True,
     disable_metrics=True,
-    instrumentations=["flask"],
     flask_config={"excluded_urls": "http://localhost:8080/ignore"},
     tracing_export_interval_millis=15000,
 )

--- a/azure-monitor-opentelemetry/samples/tracing/http_requests.py
+++ b/azure-monitor-opentelemetry/samples/tracing/http_requests.py
@@ -16,7 +16,6 @@ configure_azure_monitor(
     connection_string="<your-connection-string>",
     disable_logging=True,
     disable_metrics=True,
-    instrumentations=["requests"],
     requests_config={"excluded_urls": "http://example.com"},
     tracing_export_interval_millis=15000,
 )

--- a/azure-monitor-opentelemetry/tests/configuration/test_util.py
+++ b/azure-monitor-opentelemetry/tests/configuration/test_util.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from azure.monitor.opentelemetry.util import _get_configurations
+from azure.monitor.opentelemetry.util.configurations import _get_configurations
 
 
 class TestUtil(unittest.TestCase):


### PR DESCRIPTION
Previously, default behavior was to enable instrumentations by passing in a configuration to name libraries that user wants to enable. This seems too tedious and adds extra code for the user.

Change default behavior to enable all instrumentations, and implement configuration to exclude certain libraries via `exclude_instrumentations` configuration. This matches with the behavior of `sitecustomize.py` in OT and in attach.