### PR TITLE
Infer pillar disablement from exporter env vars.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [1.0.0b11](https://github.com/microsoft/ApplicationInsights-Python/releases/tag/v1.0.0b11) - 2023-04-12
 
+- Infer telemetry category disablement from exporter environment variables
+    ([#278](https://github.com/microsoft/ApplicationInsights-Python/pull/278))
 - Reverse default behavior of instrumentations and implement configuration for exclusion
     ([#253](https://github.com/microsoft/ApplicationInsights-Python/pull/253))
 - Use entrypoints instead of importlib to load instrumentations

--- a/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/configurations.py
+++ b/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/configurations.py
@@ -23,12 +23,12 @@ from azure.monitor.opentelemetry._constants import (
     VIEWS_ARG,
 )
 from azure.monitor.opentelemetry._types import ConfigurationValue
-from opentelemetry.sdk.environment_variables import OTEL_TRACES_SAMPLER_ARG
 from opentelemetry.environment_variables import (
     OTEL_LOGS_EXPORTER,
     OTEL_METRICS_EXPORTER,
     OTEL_TRACES_EXPORTER,
 )
+from opentelemetry.sdk.environment_variables import OTEL_TRACES_SAMPLER_ARG
 
 _INVALID_FLOAT_MESSAGE = "Value of %s must be a float. Defaulting to %s: %s"
 

--- a/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/configurations.py
+++ b/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/configurations.py
@@ -24,6 +24,7 @@ from azure.monitor.opentelemetry._constants import (
 )
 from azure.monitor.opentelemetry._types import ConfigurationValue
 from opentelemetry.sdk.environment_variables import OTEL_TRACES_SAMPLER_ARG
+from opentelemetry.environment_variables import OTEL_LOGS_EXPORTER, OTEL_METRICS_EXPORTER, OTEL_TRACES_EXPORTER
 
 _INVALID_FLOAT_MESSAGE = "Value of %s must be a float. Defaulting to %s: %s"
 
@@ -72,17 +73,29 @@ def _default_exclude_instrumentations(configurations):
 
 def _default_disable_logging(configurations):
     if DISABLE_LOGGING_ARG not in configurations:
-        configurations[DISABLE_LOGGING_ARG] = False
+        default = False
+        if OTEL_LOGS_EXPORTER in environ:
+            if environ[OTEL_LOGS_EXPORTER].lower().strip() == "none":
+                default = True
+        configurations[DISABLE_LOGGING_ARG] = default
 
 
 def _default_disable_metrics(configurations):
     if DISABLE_METRICS_ARG not in configurations:
-        configurations[DISABLE_METRICS_ARG] = False
+        default = False
+        if OTEL_METRICS_EXPORTER in environ:
+            if environ[OTEL_METRICS_EXPORTER].lower().strip() == "none":
+                default = True
+        configurations[DISABLE_METRICS_ARG] = default
 
 
 def _default_disable_tracing(configurations):
     if DISABLE_TRACING_ARG not in configurations:
-        configurations[DISABLE_TRACING_ARG] = False
+        default = False
+        if OTEL_TRACES_EXPORTER in environ:
+            if environ[OTEL_TRACES_EXPORTER].lower().strip() == "none":
+                default = True
+        configurations[DISABLE_TRACING_ARG] = default
 
 
 def _default_logging_level(configurations):

--- a/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/configurations.py
+++ b/azure-monitor-opentelemetry/azure/monitor/opentelemetry/util/configurations.py
@@ -24,7 +24,11 @@ from azure.monitor.opentelemetry._constants import (
 )
 from azure.monitor.opentelemetry._types import ConfigurationValue
 from opentelemetry.sdk.environment_variables import OTEL_TRACES_SAMPLER_ARG
-from opentelemetry.environment_variables import OTEL_LOGS_EXPORTER, OTEL_METRICS_EXPORTER, OTEL_TRACES_EXPORTER
+from opentelemetry.environment_variables import (
+    OTEL_LOGS_EXPORTER,
+    OTEL_METRICS_EXPORTER,
+    OTEL_TRACES_EXPORTER,
+)
 
 _INVALID_FLOAT_MESSAGE = "Value of %s must be a float. Defaulting to %s: %s"
 

--- a/azure-monitor-opentelemetry/samples/logging/logs_with_traces.py
+++ b/azure-monitor-opentelemetry/samples/logging/logs_with_traces.py
@@ -14,7 +14,6 @@ configure_azure_monitor(
     logger_name=__name__,
     logging_level=WARNING,
     disable_metrics=True,
-    instrumentations=["flask"],
     tracing_export_interval_ms=15000,
 )
 

--- a/azure-monitor-opentelemetry/tests/configuration/test_util.py
+++ b/azure-monitor-opentelemetry/tests/configuration/test_util.py
@@ -110,7 +110,7 @@ class TestUtil(TestCase):
             SAMPLING_RATIO_ENV_VAR: "0.5",
             OTEL_TRACES_EXPORTER: "None",
             OTEL_LOGS_EXPORTER: "none",
-            OTEL_METRICS_EXPORTER: "NONE", 
+            OTEL_METRICS_EXPORTER: "NONE",
         },
         clear=True,
     )
@@ -139,7 +139,7 @@ class TestUtil(TestCase):
             SAMPLING_RATIO_ENV_VAR: "Half",
             OTEL_TRACES_EXPORTER: "False",
             OTEL_LOGS_EXPORTER: "no",
-            OTEL_METRICS_EXPORTER: "True", 
+            OTEL_METRICS_EXPORTER: "True",
         },
         clear=True,
     )

--- a/azure-monitor-opentelemetry/tests/configuration/test_util.py
+++ b/azure-monitor-opentelemetry/tests/configuration/test_util.py
@@ -21,6 +21,11 @@ from azure.monitor.opentelemetry.util.configurations import (
     SAMPLING_RATIO_ENV_VAR,
     _get_configurations,
 )
+from opentelemetry.environment_variables import (
+    OTEL_TRACES_EXPORTER,
+    OTEL_LOGS_EXPORTER,
+    OTEL_METRICS_EXPORTER,
+)
 
 
 class TestUtil(TestCase):
@@ -31,7 +36,6 @@ class TestUtil(TestCase):
             disable_logging="test_disable_logging",
             disable_metrics="test_disable_metrics",
             disable_tracing="test_disable_tracing",
-            instrumentations=["test_instrumentation"],
             logging_level="test_logging_level",
             logger_name="test_logger_name",
             resource="test_resource",
@@ -104,6 +108,9 @@ class TestUtil(TestCase):
         {
             LOGGING_EXPORT_INTERVAL_MS_ENV_VAR: "10000",
             SAMPLING_RATIO_ENV_VAR: "0.5",
+            OTEL_TRACES_EXPORTER: "None",
+            OTEL_LOGS_EXPORTER: "none",
+            OTEL_METRICS_EXPORTER: "NONE", 
         },
         clear=True,
     )
@@ -112,9 +119,9 @@ class TestUtil(TestCase):
 
         self.assertTrue("connection_string" not in configurations)
         self.assertEqual(configurations["exclude_instrumentations"], [])
-        self.assertEqual(configurations["disable_logging"], False)
-        self.assertEqual(configurations["disable_metrics"], False)
-        self.assertEqual(configurations["disable_tracing"], False)
+        self.assertEqual(configurations["disable_logging"], True)
+        self.assertEqual(configurations["disable_metrics"], True)
+        self.assertEqual(configurations["disable_tracing"], True)
         self.assertEqual(configurations["logging_level"], NOTSET)
         self.assertEqual(configurations["logger_name"], "")
         self.assertTrue("resource" not in configurations)
@@ -130,6 +137,9 @@ class TestUtil(TestCase):
         {
             LOGGING_EXPORT_INTERVAL_MS_ENV_VAR: "Ten Thousand",
             SAMPLING_RATIO_ENV_VAR: "Half",
+            OTEL_TRACES_EXPORTER: "False",
+            OTEL_LOGS_EXPORTER: "no",
+            OTEL_METRICS_EXPORTER: "True", 
         },
         clear=True,
     )

--- a/azure-monitor-opentelemetry/tests/configuration/test_util.py
+++ b/azure-monitor-opentelemetry/tests/configuration/test_util.py
@@ -22,9 +22,9 @@ from azure.monitor.opentelemetry.util.configurations import (
     _get_configurations,
 )
 from opentelemetry.environment_variables import (
-    OTEL_TRACES_EXPORTER,
     OTEL_LOGS_EXPORTER,
     OTEL_METRICS_EXPORTER,
+    OTEL_TRACES_EXPORTER,
 )
 
 


### PR DESCRIPTION
Setting the exporters to "None" is a way to disable a pillar. This logic is already used in [OTEL auto-instrumentation](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py#L183)