### PR TITLE
Fix bug where env var logic for attach was being run for distro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
     ([#295](https://github.com/microsoft/ApplicationInsights-Python/pull/295))
 - Enable Azure Core Tracing OpenTelemetry plugin
     ([#269](https://github.com/microsoft/ApplicationInsights-Python/pull/269))
+- Fix connection string environment variable bug for manual instrumentation
+    ([#302](https://github.com/microsoft/ApplicationInsights-Python/pull/302))
 
 ## [1.0.0b13](https://github.com/microsoft/ApplicationInsights-Python/releases/tag/v1.0.0b13) - 2023-06-14
 

--- a/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
+++ b/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
@@ -36,12 +36,19 @@ _IS_DIAGNOSTICS_ENABLED = _IS_ON_APP_SERVICE
 # _EXPORTER_DIAGNOSTICS_ENABLED_ENV_VAR = (
 #     "AZURE_MONITOR_OPENTELEMETRY_DISTRO_ENABLE_EXPORTER_DIAGNOSTICS"
 # )
+_CUSTOMER_IKEY_ENV_VAR = None
 logger = logging.getLogger(__name__)
-_CUSTOMER_IKEY = "unknown"
-try:
-    _CUSTOMER_IKEY = ConnectionStringParser().instrumentation_key
-except ValueError as e:
-    logger.error("Failed to parse Instrumentation Key: %s", e)
+
+
+def _get_customer_ikey_from_env_var():
+    global _CUSTOMER_IKEY_ENV_VAR
+    if not _CUSTOMER_IKEY_ENV_VAR:
+        _CUSTOMER_IKEY_ENV_VAR = "unknown"
+        try:
+            _CUSTOMER_IKEY_ENV_VAR = ConnectionStringParser().instrumentation_key
+        except ValueError as e:
+            logger.error("Failed to parse Instrumentation Key: %s", e)
+    return _CUSTOMER_IKEY_ENV_VAR
 
 
 def _get_log_path(status_log_path=False):

--- a/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
+++ b/azure-monitor-opentelemetry/azure/monitor/opentelemetry/_constants.py
@@ -45,7 +45,9 @@ def _get_customer_ikey_from_env_var():
     if not _CUSTOMER_IKEY_ENV_VAR:
         _CUSTOMER_IKEY_ENV_VAR = "unknown"
         try:
-            _CUSTOMER_IKEY_ENV_VAR = ConnectionStringParser().instrumentation_key
+            _CUSTOMER_IKEY_ENV_VAR = (
+                ConnectionStringParser().instrumentation_key
+            )
         except ValueError as e:
             logger.error("Failed to parse Instrumentation Key: %s", e)
     return _CUSTOMER_IKEY_ENV_VAR

--- a/azure-monitor-opentelemetry/azure/monitor/opentelemetry/diagnostics/_diagnostic_logging.py
+++ b/azure-monitor-opentelemetry/azure/monitor/opentelemetry/diagnostics/_diagnostic_logging.py
@@ -10,10 +10,10 @@ from os import makedirs
 from os.path import exists, join
 
 from azure.monitor.opentelemetry._constants import (
-    _CUSTOMER_IKEY,
     _EXTENSION_VERSION,
     _IS_DIAGNOSTICS_ENABLED,
     _env_var_or_default,
+    _get_customer_ikey_from_env_var,
     _get_log_path,
 )
 from azure.monitor.opentelemetry._version import VERSION
@@ -49,7 +49,7 @@ class AzureDiagnosticLogging:
                         + '"properties":{'
                         + '"operation":"Startup", '
                         + f'"sitename":"{_SITE_NAME}", '
-                        + f'"ikey":"{_CUSTOMER_IKEY}", '
+                        + f'"ikey":"{_get_customer_ikey_from_env_var()}", '
                         + f'"extensionVersion":"{_EXTENSION_VERSION}", '
                         + f'"sdkVersion":"{VERSION}", '
                         + f'"subscriptionId":"{_SUBSCRIPTION_ID}", '

--- a/azure-monitor-opentelemetry/azure/monitor/opentelemetry/diagnostics/_status_logger.py
+++ b/azure-monitor-opentelemetry/azure/monitor/opentelemetry/diagnostics/_status_logger.py
@@ -10,9 +10,9 @@ from os.path import exists, join
 from platform import node
 
 from azure.monitor.opentelemetry._constants import (
-    _CUSTOMER_IKEY,
     _EXTENSION_VERSION,
     _IS_DIAGNOSTICS_ENABLED,
+    _get_customer_ikey_from_env_var,
     _get_log_path,
 )
 from azure.monitor.opentelemetry._version import VERSION
@@ -32,7 +32,7 @@ class AzureStatusLogger:
             "MachineName": _MACHINE_NAME,
             "PID": pid,
             "SdkVersion": VERSION,
-            "Ikey": _CUSTOMER_IKEY,
+            "Ikey": _get_customer_ikey_from_env_var(),
             "ExtensionVersion": _EXTENSION_VERSION,
         }
         if reason:

--- a/azure-monitor-opentelemetry/tests/diagnostics/test_diagnostic_logging.py
+++ b/azure-monitor-opentelemetry/tests/diagnostics/test_diagnostic_logging.py
@@ -96,8 +96,8 @@ def set_up(
         TEST_DIAGNOSTIC_LOGGER_FILE_NAME,
     ).start()
     patch(
-        "azure.monitor.opentelemetry.diagnostics._diagnostic_logging._CUSTOMER_IKEY",
-        TEST_CUSTOMER_IKEY,
+        "azure.monitor.opentelemetry.diagnostics._diagnostic_logging._get_customer_ikey_from_env_var",
+        return_value=TEST_CUSTOMER_IKEY,
     ).start()
     patch(
         "azure.monitor.opentelemetry.diagnostics._diagnostic_logging._EXTENSION_VERSION",

--- a/azure-monitor-opentelemetry/tests/diagnostics/test_status_logger.py
+++ b/azure-monitor-opentelemetry/tests/diagnostics/test_status_logger.py
@@ -73,8 +73,8 @@ class TestStatusLogger(TestCase):
         TEST_LOGGER_PATH,
     )
     @patch(
-        "azure.monitor.opentelemetry.diagnostics._status_logger._CUSTOMER_IKEY",
-        TEST_CUSTOMER_IKEY,
+        "azure.monitor.opentelemetry.diagnostics._status_logger._get_customer_ikey_from_env_var",
+        return_value=TEST_CUSTOMER_IKEY,
     )
     @patch(
         "azure.monitor.opentelemetry.diagnostics._status_logger._EXTENSION_VERSION",
@@ -96,7 +96,7 @@ class TestStatusLogger(TestCase):
         "azure.monitor.opentelemetry.diagnostics._status_logger._MACHINE_NAME",
         TEST_MACHINE_NAME,
     )
-    def test_log_status_success(self, mock_getpid):
+    def test_log_status_success(self, mock_getpid, mock_get_ikey):
         AzureStatusLogger.log_status(False, MESSAGE1)
         AzureStatusLogger.log_status(True, MESSAGE2)
         check_file_for_messages(True, MESSAGE2)
@@ -106,8 +106,8 @@ class TestStatusLogger(TestCase):
         TEST_LOGGER_PATH,
     )
     @patch(
-        "azure.monitor.opentelemetry.diagnostics._status_logger._CUSTOMER_IKEY",
-        TEST_CUSTOMER_IKEY,
+        "azure.monitor.opentelemetry.diagnostics._status_logger._get_customer_ikey_from_env_var",
+        return_value=TEST_CUSTOMER_IKEY,
     )
     @patch(
         "azure.monitor.opentelemetry.diagnostics._status_logger._EXTENSION_VERSION",
@@ -129,7 +129,7 @@ class TestStatusLogger(TestCase):
         "azure.monitor.opentelemetry.diagnostics._status_logger._MACHINE_NAME",
         TEST_MACHINE_NAME,
     )
-    def test_log_status_failed_initialization(self, mock_getpid):
+    def test_log_status_failed_initialization(self, mock_getpid, mock_get_ikey):
         AzureStatusLogger.log_status(True, MESSAGE1)
         AzureStatusLogger.log_status(False, MESSAGE2)
         check_file_for_messages(False, MESSAGE2)
@@ -139,8 +139,8 @@ class TestStatusLogger(TestCase):
         TEST_LOGGER_PATH,
     )
     @patch(
-        "azure.monitor.opentelemetry.diagnostics._status_logger._CUSTOMER_IKEY",
-        TEST_CUSTOMER_IKEY,
+        "azure.monitor.opentelemetry.diagnostics._status_logger._get_customer_ikey_from_env_var",
+        return_value=TEST_CUSTOMER_IKEY,
     )
     @patch(
         "azure.monitor.opentelemetry.diagnostics._status_logger._EXTENSION_VERSION",
@@ -162,7 +162,7 @@ class TestStatusLogger(TestCase):
         "azure.monitor.opentelemetry.diagnostics._status_logger._MACHINE_NAME",
         TEST_MACHINE_NAME,
     )
-    def test_log_status_no_reason(self, mock_getpid):
+    def test_log_status_no_reason(self, mock_getpid, mock_get_ikey):
         AzureStatusLogger.log_status(False, MESSAGE1)
         AzureStatusLogger.log_status(True)
         check_file_for_messages(True)
@@ -172,8 +172,8 @@ class TestStatusLogger(TestCase):
         TEST_LOGGER_PATH,
     )
     @patch(
-        "azure.monitor.opentelemetry.diagnostics._status_logger._CUSTOMER_IKEY",
-        TEST_CUSTOMER_IKEY,
+        "azure.monitor.opentelemetry.diagnostics._status_logger._get_customer_ikey_from_env_var",
+        return_value=TEST_CUSTOMER_IKEY,
     )
     @patch(
         "azure.monitor.opentelemetry.diagnostics._status_logger._EXTENSION_VERSION",
@@ -195,7 +195,7 @@ class TestStatusLogger(TestCase):
         "azure.monitor.opentelemetry.diagnostics._status_logger._MACHINE_NAME",
         TEST_MACHINE_NAME,
     )
-    def test_disabled_log_status_success(self, mock_getpid):
+    def test_disabled_log_status_success(self, mock_getpid, mock_get_ikey):
         AzureStatusLogger.log_status(False, MESSAGE1)
         AzureStatusLogger.log_status(True, MESSAGE2)
         check_file_is_empty()
@@ -205,8 +205,8 @@ class TestStatusLogger(TestCase):
         TEST_LOGGER_PATH,
     )
     @patch(
-        "azure.monitor.opentelemetry.diagnostics._status_logger._CUSTOMER_IKEY",
-        TEST_CUSTOMER_IKEY,
+        "azure.monitor.opentelemetry.diagnostics._status_logger._get_customer_ikey_from_env_var",
+        return_value=TEST_CUSTOMER_IKEY,
     )
     @patch(
         "azure.monitor.opentelemetry.diagnostics._status_logger._EXTENSION_VERSION",
@@ -228,7 +228,7 @@ class TestStatusLogger(TestCase):
         "azure.monitor.opentelemetry.diagnostics._status_logger._MACHINE_NAME",
         TEST_MACHINE_NAME,
     )
-    def test_disabled_log_status_failed_initialization(self, mock_getpid):
+    def test_disabled_log_status_failed_initialization(self, mock_getpid, mock_get_ikey):
         AzureStatusLogger.log_status(True, MESSAGE1)
         AzureStatusLogger.log_status(False, MESSAGE2)
         check_file_is_empty()
@@ -238,8 +238,8 @@ class TestStatusLogger(TestCase):
         TEST_LOGGER_PATH,
     )
     @patch(
-        "azure.monitor.opentelemetry.diagnostics._status_logger._CUSTOMER_IKEY",
-        TEST_CUSTOMER_IKEY,
+        "azure.monitor.opentelemetry.diagnostics._status_logger._get_customer_ikey_from_env_var",
+        return_value=TEST_CUSTOMER_IKEY,
     )
     @patch(
         "azure.monitor.opentelemetry.diagnostics._status_logger._EXTENSION_VERSION",
@@ -261,7 +261,7 @@ class TestStatusLogger(TestCase):
         "azure.monitor.opentelemetry.diagnostics._status_logger._MACHINE_NAME",
         TEST_MACHINE_NAME,
     )
-    def test_disabled_log_status_no_reason(self, mock_getpid):
+    def test_disabled_log_status_no_reason(self, mock_getpid, mock_get_ikey):
         AzureStatusLogger.log_status(False, MESSAGE1)
         AzureStatusLogger.log_status(True)
         check_file_is_empty()

--- a/azure-monitor-opentelemetry/tests/diagnostics/test_status_logger.py
+++ b/azure-monitor-opentelemetry/tests/diagnostics/test_status_logger.py
@@ -129,7 +129,9 @@ class TestStatusLogger(TestCase):
         "azure.monitor.opentelemetry.diagnostics._status_logger._MACHINE_NAME",
         TEST_MACHINE_NAME,
     )
-    def test_log_status_failed_initialization(self, mock_getpid, mock_get_ikey):
+    def test_log_status_failed_initialization(
+        self, mock_getpid, mock_get_ikey
+    ):
         AzureStatusLogger.log_status(True, MESSAGE1)
         AzureStatusLogger.log_status(False, MESSAGE2)
         check_file_for_messages(False, MESSAGE2)
@@ -228,7 +230,9 @@ class TestStatusLogger(TestCase):
         "azure.monitor.opentelemetry.diagnostics._status_logger._MACHINE_NAME",
         TEST_MACHINE_NAME,
     )
-    def test_disabled_log_status_failed_initialization(self, mock_getpid, mock_get_ikey):
+    def test_disabled_log_status_failed_initialization(
+        self, mock_getpid, mock_get_ikey
+    ):
         AzureStatusLogger.log_status(True, MESSAGE1)
         AzureStatusLogger.log_status(False, MESSAGE2)
         check_file_is_empty()

--- a/azure-monitor-opentelemetry/tests/test_constants.py
+++ b/azure-monitor-opentelemetry/tests/test_constants.py
@@ -40,12 +40,12 @@ class TestConstants(TestCase):
     )
     def test_ikey(self):
         reload(_constants)
-        self.assertEqual(_constants._CUSTOMER_IKEY, TEST_IKEY)
+        self.assertEqual(_constants._get_customer_ikey_from_env_var(), TEST_IKEY)
 
     def test_ikey_defaults(self):
         clear_env_var("APPLICATIONINSIGHTS_CONNECTION_STRING")
         reload(_constants)
-        self.assertEqual(_constants._CUSTOMER_IKEY, "unknown")
+        self.assertEqual(_constants._get_customer_ikey_from_env_var(), "unknown")
 
     # TODO: Enabled when duplicate logging issue is solved
     # @patch.dict(

--- a/azure-monitor-opentelemetry/tests/test_constants.py
+++ b/azure-monitor-opentelemetry/tests/test_constants.py
@@ -40,12 +40,16 @@ class TestConstants(TestCase):
     )
     def test_ikey(self):
         reload(_constants)
-        self.assertEqual(_constants._get_customer_ikey_from_env_var(), TEST_IKEY)
+        self.assertEqual(
+            _constants._get_customer_ikey_from_env_var(), TEST_IKEY
+        )
 
     def test_ikey_defaults(self):
         clear_env_var("APPLICATIONINSIGHTS_CONNECTION_STRING")
         reload(_constants)
-        self.assertEqual(_constants._get_customer_ikey_from_env_var(), "unknown")
+        self.assertEqual(
+            _constants._get_customer_ikey_from_env_var(), "unknown"
+        )
 
     # TODO: Enabled when duplicate logging issue is solved
     # @patch.dict(


### PR DESCRIPTION
Fixing a bug where the logic checking the conn str env var for attach diagnostic logging was running during manual instrumentaiton.