### PR TITLE
Update setup.py for correct package_data

### DIFF
--- a/azure-monitor-events-extension/setup.py
+++ b/azure-monitor-events-extension/setup.py
@@ -61,7 +61,7 @@ setup(
     ),
     include_package_data=True,
     package_data={
-        "pytyped": ["py.typed"],
+        "": ["py.typed"],
     },
     python_requires=">=3.7",
     install_requires=[


### PR DESCRIPTION
This corrects the package_data block such that `py.typed` applies to all modules instead of a non-existent `py.typed` module.

This will allow correct typing for consumers of the package.

Related to PEP 561.